### PR TITLE
feat(vouchers)/add_billing_cycle_to_voucher_plan: add column database…

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -29,7 +29,13 @@ class Api::V1::SubscriptionsController < Api::BaseController
 
     # Apply voucher if present
     if voucher_code.present?
-      result = Voucher::VoucherPreview.new.preview(voucher_code, @account, @subscription_plan.id, price)
+      result = Voucher::VoucherPreview.new.preview(
+        voucher_code, 
+        @account, 
+        @subscription_plan.id, 
+        price,
+        billing_cycle: billing_cycle
+      )
       if result[:voucher][:valid]
         voucher = result[:voucher][:voucher]
         price = result[:new_price]

--- a/app/controllers/api/v1/vouchers_controller.rb
+++ b/app/controllers/api/v1/vouchers_controller.rb
@@ -3,8 +3,14 @@ class Api::V1::VouchersController < ApplicationController
     account = Account.find(params[:account_id]) unless params[:account_id].nil?
     plan_id = params[:subscription_plan_id]
     code = params[:voucher_code]
+    billing_cycle = params[:billing_cycle]
 
-    result =  ::Voucher::VoucherValidator.new(code: code, account: account, subscription_plan_id: plan_id).validate
+    result = ::Voucher::VoucherValidator.new(
+      code: code, 
+      account: account, 
+      subscription_plan_id: plan_id,
+      billing_cycle: billing_cycle
+    ).validate
 
     if result[:valid]
       render json: {
@@ -22,8 +28,9 @@ class Api::V1::VouchersController < ApplicationController
     plan_id = params[:subscription_plan_id]
     code = params[:voucher_code]
     price = params[:price]
+    billing_cycle = params[:billing_cycle]
 
-    result = Voucher::VoucherPreview.new().preview(code, account, plan_id, price)
+    result = Voucher::VoucherPreview.new().preview(code, account, plan_id, price, billing_cycle: billing_cycle)
     if result[:voucher][:valid]
       render json: result
     else

--- a/app/javascript/dashboard/routes/dashboard/settings/billing/components/Payment.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/billing/components/Payment.vue
@@ -120,6 +120,13 @@ const selectBillingCycle = cycle => {
   isDropdownOpen.value = false;
 };
 
+// Close dropdown saat validating voucher
+watch(() => isValidatingVoucher.value, (newVal) => {
+  if (newVal) {
+    isDropdownOpen.value = false;
+  }
+});
+
 const rules = {
   packageName: { required, minLength: minLength(1) },
 };
@@ -293,7 +300,13 @@ const submit = async () => {
         </div>
       </div>
 
-      <PaymentVoucherInput :subscriptionPlanId="selectedPlan?.id" :selectedPrice="totalPrice" v-model="selectedVoucher" v-model:is-validating-voucher="isValidatingVoucher"/>
+      <PaymentVoucherInput 
+        :subscriptionPlanId="selectedPlan?.id" 
+        :selectedPrice="totalPrice" 
+        :billingCycle="selectedBillingCycle?.id"
+        v-model="selectedVoucher" 
+        v-model:is-validating-voucher="isValidatingVoucher"
+      />
 
       <!-- Total -->
        <div class="flex flex-row justify-end mt-3">

--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -34,7 +34,8 @@
 #
 class SubscriptionPlan < ApplicationRecord
   has_many :subscriptions
-  has_and_belongs_to_many :vouchers
+  has_many :subscription_plan_vouchers
+  has_many :vouchers, through: :subscription_plan_vouchers
   belongs_to :owner_account, class_name: 'Account', optional: true
 
   validates :owner_account_id, presence: true, if: :is_custom?

--- a/app/models/subscription_plan_voucher.rb
+++ b/app/models/subscription_plan_voucher.rb
@@ -1,0 +1,40 @@
+# == Schema Information
+#
+# Table name: subscription_plans_vouchers
+#
+#  id                        :bigint           not null, primary key
+#  applicable_billing_cycles :text             default(["\"monthly\"", "\"quarterly\"", "\"halfyear\"", "\"yearly\""]), is an Array
+#  subscription_plan_id      :bigint           not null
+#  voucher_id                :bigint           not null
+#
+# Indexes
+#
+#  index_plan_voucher  (subscription_plan_id,voucher_id)
+#
+class SubscriptionPlanVoucher < ApplicationRecord
+  self.table_name = 'subscription_plans_vouchers'
+  
+  belongs_to :subscription_plan
+  belongs_to :voucher
+
+  BILLING_CYCLES = %w[monthly quarterly halfyear yearly].freeze
+  
+  validates :applicable_billing_cycles, presence: true
+  validate :validate_billing_cycles
+
+  # Mengecek apakah billing cycle tertentu applicable
+  def applicable_to?(billing_cycle)
+    applicable_billing_cycles.include?(billing_cycle.to_s) || applicable_billing_cycles.empty?
+  end
+
+  private
+
+  def validate_billing_cycles
+    return if applicable_billing_cycles.blank?
+    
+    invalid = applicable_billing_cycles - BILLING_CYCLES
+    if invalid.any?
+      errors.add(:applicable_billing_cycles, "contains invalid values: #{invalid.join(', ')}")
+    end
+  end
+end

--- a/app/models/voucher.rb
+++ b/app/models/voucher.rb
@@ -19,7 +19,8 @@
 #  index_vouchers_on_code  (code) UNIQUE
 #
 class Voucher < ApplicationRecord
-  has_and_belongs_to_many :subscription_plans
+  has_many :subscription_plan_vouchers
+  has_many :subscription_plans, through: :subscription_plan_vouchers
   has_many :voucher_usages
 
   enum discount_type: { idr: 'idr', percentage: 'percentage' }
@@ -30,10 +31,34 @@ class Voucher < ApplicationRecord
     Date.today.between?(start_date, end_date)
   end
 
-  def usable_by?(account)
+  # Cek apakah voucher applicable untuk plan dan billing cycle tertentu
+  def applicable_to_plan_and_cycle?(plan_id, billing_cycle)
+    subscription_plan_vouchers
+      .where(subscription_plan_id: plan_id)
+      .where("? = ANY(applicable_billing_cycles) OR applicable_billing_cycles = '{}'", billing_cycle.to_s)
+      .exists?
+  end
+
+  # Cek apakah voucher bisa digunakan oleh account untuk plan dan billing cycle tertentu
+  def usable_by?(account, subscription_plan_id = nil, billing_cycle = nil)
     return false unless active?
+    
+    # Jika subscription_plan_id dan billing_cycle disediakan, cek applicable
+    if subscription_plan_id.present? && billing_cycle.present?
+      return false unless applicable_to_plan_and_cycle?(subscription_plan_id, billing_cycle)
+    end
+    
+    # Cek apakah sudah pernah digunakan (jika tidak recurring)
     return false if !is_recurring && voucher_usages.exists?(account_id: account.id)
+    
+    # Cek usage limit
     return false if usage_limit && voucher_usages.count >= usage_limit
+    
     true
+  end
+
+  # Method backward compatible untuk kasus tanpa billing cycle
+  def usable_by_account?(account)
+    usable_by?(account)
   end
 end

--- a/app/services/voucher/voucher_preview.rb
+++ b/app/services/voucher/voucher_preview.rb
@@ -1,6 +1,12 @@
 class Voucher::VoucherPreview
-  def preview(code, account, subscription_plan_id, price)
-    result = Voucher::VoucherValidator.new(code: code, account: account, subscription_plan_id: subscription_plan_id).validate
+  def preview(code, account, subscription_plan_id, price, billing_cycle: nil)
+    result = Voucher::VoucherValidator.new(
+      code: code, 
+      account: account, 
+      subscription_plan_id: subscription_plan_id,
+      billing_cycle: billing_cycle
+    ).validate
+
     unless result[:valid]
       return {
         voucher: result,

--- a/app/services/voucher/voucher_validator.rb
+++ b/app/services/voucher/voucher_validator.rb
@@ -1,8 +1,9 @@
 class Voucher::VoucherValidator
-  def initialize(code:, account:, subscription_plan_id:)
+  def initialize(code:, account:, subscription_plan_id:, billing_cycle: nil)
     @code = code
     @account = account
     @plan_id = subscription_plan_id
+    @billing_cycle = billing_cycle
   end
 
   def validate
@@ -13,7 +14,15 @@ class Voucher::VoucherValidator
       return { valid: false, error: 'Voucher tidak berlaku untuk paket ini' }
     end
 
-    unless voucher.usable_by?(@account)
+    # Validasi billing cycle
+    if @billing_cycle.present?
+      unless voucher.applicable_to_plan_and_cycle?(@plan_id, @billing_cycle)
+        return { valid: false, error: 'Voucher tidak berlaku untuk siklus pembayaran ini' }
+      end
+    end
+
+    # Gunakan method usable_by? dengan billing_cycle
+    unless voucher.usable_by?(@account, @plan_id, @billing_cycle)
       return { valid: false, error: 'Voucher tidak bisa digunakan lagi' }
     end
 

--- a/db/migrate/20251119074500_add_billing_cycles_to_subscription_plans_vouchers.rb
+++ b/db/migrate/20251119074500_add_billing_cycles_to_subscription_plans_vouchers.rb
@@ -1,0 +1,8 @@
+class AddBillingCyclesToSubscriptionPlansVouchers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :subscription_plans_vouchers, :applicable_billing_cycles, :text, 
+               array: true, default: ['monthly', 'quarterly', 'halfyear', 'yearly']
+    
+    add_column :subscription_plans_vouchers, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_11_06_062528) do
+ActiveRecord::Schema[7.0].define(version: 2025_11_19_074500) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -1194,9 +1194,10 @@ ActiveRecord::Schema[7.0].define(version: 2025_11_06_062528) do
     t.index ["owner_account_id"], name: "index_subscription_plans_on_owner_account_id"
   end
 
-  create_table "subscription_plans_vouchers", id: false, force: :cascade do |t|
+  create_table "subscription_plans_vouchers", force: :cascade do |t|
     t.bigint "subscription_plan_id", null: false
     t.bigint "voucher_id", null: false
+    t.text "applicable_billing_cycles", default: ["monthly", "quarterly", "halfyear", "yearly"], array: true
     t.index ["subscription_plan_id", "voucher_id"], name: "index_plan_voucher"
   end
 


### PR DESCRIPTION
- Add support for billing cycle-specific voucher validation.
- Add applicable_billing_cycles array column with default values
  "monthly, quarterly, halfyear, yearly}
- if applicable_billing_cycles = empty or {}, vouchers can be used for all cycles 
