### PR TITLE
Fix reminder config save timeout and circular serialization

### DIFF
--- a/.env:Zone.Identifier
+++ b/.env:Zone.Identifier
@@ -1,2 +1,0 @@
-[ZoneTransfer]
-ZoneId=3

--- a/app/controllers/api/v2/accounts/reminders_controller.rb
+++ b/app/controllers/api/v2/accounts/reminders_controller.rb
@@ -1,11 +1,11 @@
 class Api::V2::Accounts::RemindersController < Api::V1::Accounts::BaseController
   before_action :set_ai_agent
-  before_action :set_reminder_config, only: [:config, :update_config]
+  before_action :set_reminder_config, only: [:show_config, :update_config]
 
   # GET /api/v2/accounts/:account_id/ai_agents/:ai_agent_id/reminders/config
-  def config
+  def show_config
     @reminder_config ||= @ai_agent.build_reminder_config(account: Current.account)
-    render json: @reminder_config, status: :ok
+    render json: reminder_config_response, status: :ok
   end
 
   # PUT /api/v2/accounts/:account_id/ai_agents/:ai_agent_id/reminders/config
@@ -13,7 +13,7 @@ class Api::V2::Accounts::RemindersController < Api::V1::Accounts::BaseController
     @reminder_config ||= @ai_agent.build_reminder_config(account: Current.account)
 
     if @reminder_config.update(reminder_config_params)
-      render json: @reminder_config, status: :ok
+      render json: reminder_config_response, status: :ok
     else
       render json: { errors: @reminder_config.errors.full_messages }, status: :unprocessable_entity
     end
@@ -27,6 +27,20 @@ class Api::V2::Accounts::RemindersController < Api::V1::Accounts::BaseController
 
   def set_reminder_config
     @reminder_config = @ai_agent.reminder_config
+  end
+
+  # Explicit response to avoid circular serialization
+  def reminder_config_response
+    {
+      id: @reminder_config.id,
+      enabled: @reminder_config.enabled,
+      minutes_before_booking: @reminder_config.minutes_before_booking,
+      message_template: @reminder_config.message_template,
+      ai_agent_id: @reminder_config.ai_agent_id,
+      account_id: @reminder_config.account_id,
+      created_at: @reminder_config.created_at,
+      updated_at: @reminder_config.updated_at
+    }
   end
 
   def reminder_params

--- a/app/controllers/api/v2/accounts/reminders_controller.rb
+++ b/app/controllers/api/v2/accounts/reminders_controller.rb
@@ -10,7 +10,7 @@ class Api::V2::Accounts::RemindersController < Api::V1::Accounts::BaseController
 
   # PUT /api/v2/accounts/:account_id/ai_agents/:ai_agent_id/reminders/config
   def update_config
-    @reminder_config ||= @ai_agent.build_reminder_config(account: Current.account)
+    @reminder_config ||= @ai_agent.create_reminder_config(account: Current.account)
 
     if @reminder_config.update(reminder_config_params)
       render json: reminder_config_response, status: :ok

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
@@ -406,14 +406,14 @@ async function save() {
       flow_data: flowData,
     };
 
-    await aiAgents.updateAgent(props.data.id, payload);
-
-    // Update reminder config in database
-    await remindersAPI.updateConfig(props.data.id, {
-      enabled: followUpConfig.enabled,
-      minutes_before_booking: followUpConfig.delay,
-      message_template: followUpConfig.message
-    });
+    await Promise.all([
+      aiAgents.updateAgent(props.data.id, payload),
+      remindersAPI.updateConfig(props.data.id, {
+        enabled: followUpConfig.enabled,
+        minutes_before_booking: followUpConfig.delay,
+        message_template: followUpConfig.message
+      })
+    ]);
 
     useAlert(t('AGENT_MGMT.CSBOT.TICKET.SAVE_SUCCESS'));
   } catch (e) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -465,7 +465,7 @@ Rails.application.routes.draw do
             # Reminders routes
             resources :reminders, only: [:index, :create, :show, :destroy] do
               collection do
-                get :config
+                get :config, action: :show_config
                 put :config, action: :update_config
               end
             end


### PR DESCRIPTION
# Pull Request Template

## Description
Fixes a long save delay and 500 error when updating AI Agent reminder settings. The /reminders/config endpoint was failing with a SystemStackError (stack level too deep) caused by circular JSON serialization between ReminderConfig and AiAgent. This resulted in large responses (~15MB) and long request times.

Fixes
- Prevent circular serialization by returning an explicit JSON response
- Rename the controller action and update routes accordingly
- Run agent update and reminder config update in parallel on the frontend

This resolves the timeout, large response size, and save failure.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Change any of the reminder config
2. Save reminder config 
3. Verify if there is 500 error and stack overflow in backend logs

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
