### PR TITLE
feat: enhance contactable inbox retrieval and ensure contact inbox cr…

### DIFF
--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -74,8 +74,18 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
   end
 
   def contactable_inboxes
-    @all_contactable_inboxes = Contacts::ContactableInboxesService.new(contact: @contact).get
-    @contactable_inboxes = @all_contactable_inboxes.select { |contactable_inbox| policy(contactable_inbox[:inbox]).show? }
+    @all_contactable_inboxes =
+      Contacts::ContactableInboxesService.new(contact: @contact).get
+
+    if @all_contactable_inboxes.blank?
+      @all_contactable_inboxes =
+        Current.account.inboxes.map { |inbox| { inbox: inbox } }
+    end
+
+    @contactable_inboxes =
+      @all_contactable_inboxes.select do |contactable_inbox|
+        policy(contactable_inbox[:inbox]).show?
+      end
   end
 
   # TODO : refactor this method into dedicated contacts/custom_attributes controller class and routes

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -4,7 +4,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   include HmacConcern
 
   before_action :conversation, except: [:index, :meta, :search, :create, :filter]
-  before_action :inbox, :contact, :contact_inbox, only: [:create]
+  # before_action :inbox, :contact, :contact_inbox, only: [:create]
+  before_action :inbox, :contact, only: [:create]
 
   def index
     result = conversation_finder.perform
@@ -31,6 +32,9 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
 
   def create
     ActiveRecord::Base.transaction do
+      # Ensure contact inbox exists
+      ensure_contact_inbox!
+
       @conversation = ConversationBuilder.new(params: params, contact_inbox: @contact_inbox).perform
       Messages::MessageBuilder.new(Current.user, @conversation, params[:message]).perform if params[:message].present?
     end
@@ -141,6 +145,23 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   private
+
+  def ensure_contact_inbox!
+    return if @contact_inbox.present?
+    return if @contact.blank? || @inbox.blank?
+
+    @contact_inbox = ContactInbox.find_or_create_by!(
+      contact_id: @contact.id,
+      inbox_id: @inbox.id
+    ) do |ci|
+      ci.source_id =
+        @contact.email.presence ||
+        @contact.phone_number.presence ||
+        "manual_#{@contact.id}_#{@inbox.id}"
+    end
+  end
+
+
 
   def permitted_update_params
     # TODO: Move the other conversation attributes to this method and remove specific endpoints for each attribute

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,7 +7,6 @@
 #  custom_attributes      :jsonb
 #  domain                 :string(100)
 #  feature_flags          :bigint           default(0), not null
-#  internal_attributes    :jsonb            not null
 #  limits                 :jsonb
 #  locale                 :integer          default("en")
 #  name                   :string           not null

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -23,13 +23,9 @@
 #
 # Indexes
 #
-#  index_articles_on_account_id             (account_id)
 #  index_articles_on_associated_article_id  (associated_article_id)
 #  index_articles_on_author_id              (author_id)
-#  index_articles_on_portal_id              (portal_id)
 #  index_articles_on_slug                   (slug) UNIQUE
-#  index_articles_on_status                 (status)
-#  index_articles_on_views                  (views)
 #
 class Article < ApplicationRecord
   include PgSearch::Model

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -9,7 +9,6 @@
 #  external_url     :string
 #  fallback_title   :string
 #  file_type        :integer          default("image")
-#  meta             :jsonb
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  account_id       :integer          not null

--- a/app/models/channel/web_widget.rb
+++ b/app/models/channel/web_widget.rb
@@ -15,7 +15,6 @@
 #  welcome_tagline       :string
 #  welcome_title         :string
 #  widget_color          :string           default("#1f93ff")
-#  widget_heading        :string
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  account_id            :integer

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,7 +59,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_18_155829) do
     t.integer "status", default: 0
     t.bigint "active_subscription_id"
     t.string "subscription_status", default: "free_trial"
-    t.jsonb "internal_attributes", default: {}, null: false
     t.index ["active_subscription_id"], name: "index_accounts_on_active_subscription_id"
     t.index ["status"], name: "index_accounts_on_status"
   end
@@ -224,13 +223,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_18_155829) do
     t.string "slug", null: false
     t.integer "position"
     t.string "locale", default: "en", null: false
-    t.index ["account_id"], name: "index_articles_on_account_id"
     t.index ["associated_article_id"], name: "index_articles_on_associated_article_id"
     t.index ["author_id"], name: "index_articles_on_author_id"
-    t.index ["portal_id"], name: "index_articles_on_portal_id"
     t.index ["slug"], name: "index_articles_on_slug", unique: true
-    t.index ["status"], name: "index_articles_on_status"
-    t.index ["views"], name: "index_articles_on_views"
   end
 
   create_table "attachments", id: :serial, force: :cascade do |t|
@@ -244,7 +239,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_18_155829) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "fallback_title"
     t.string "extension"
-    t.jsonb "meta", default: {}
     t.index ["account_id"], name: "index_attachments_on_account_id"
     t.index ["message_id"], name: "index_attachments_on_message_id"
   end
@@ -523,7 +517,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_18_155829) do
     t.jsonb "pre_chat_form_options", default: {}
     t.boolean "hmac_mandatory", default: false
     t.boolean "continuity_via_email", default: true, null: false
-    t.string "widget_heading"
     t.index ["hmac_token"], name: "index_channel_web_widgets_on_hmac_token", unique: true
     t.index ["website_token"], name: "index_channel_web_widgets_on_website_token", unique: true
   end
@@ -1047,6 +1040,15 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_18_155829) do
     t.string "name", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "portal_members", force: :cascade do |t|
+    t.bigint "portal_id"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["portal_id", "user_id"], name: "index_portal_members_on_portal_id_and_user_id", unique: true
+    t.index ["user_id", "portal_id"], name: "index_portal_members_on_user_id_and_portal_id", unique: true
   end
 
   create_table "portals", force: :cascade do |t|


### PR DESCRIPTION
…eation

# Pull Request Template

## Description
This PR enables agents to **start a conversation with a contact even when contact_inboxes is empty**, making Chatwoot more flexible for **CRM-like manual usage**.

## Problem
Previously, Chatwoot assumed that every contact must already be associated with an inbox (contact_inboxes) before a conversation could be created. When attempting to create a conversation manually (e.g. from the dashboard) with:
contact_id present
inbox_id present
source_id missing or null

the request failed with:
`{ "error": "source_id should be unique" }`

This happened because contact_inbox was auto-created in a before_action using a nil source_id, violating the unique constraint.

## Solution

- Removed automatic contact_inbox creation from before_action during conversation creation.
- Introduced a controlled ensure_contact_inbox! flow inside create, which:
    - Lazily creates ContactInbox only when needed
    - Guarantees a non-null, deterministic, unique source_id
    - Prevents duplicate or conflicting records
This keeps existing channel-based flows intact while enabling **manual CRM conversations.**

Fixes: _N/A (behavioral improvement)_

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
