### PR TITLE
feat: filter contactable inboxes to include only WhatsApp channels

### DIFF
--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -86,6 +86,20 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
       @all_contactable_inboxes.select do |contactable_inbox|
         policy(contactable_inbox[:inbox]).show?
       end
+
+    # FILTER WHATSAPP INBOXES ONLY
+    @contactable_inboxes.select! do |contactable_inbox|
+      inbox = contactable_inbox[:inbox]
+      channel = inbox.channel
+
+      # WhatsApp Official / Unofficial
+      channel.class.name == 'Channel::WhatsappUnofficial' ||
+        (
+          channel.class.name == 'Channel::TwilioSms' &&
+          channel.respond_to?(:medium) &&
+          channel.medium == 'whatsapp'
+        )
+    end
   end
 
   # TODO : refactor this method into dedicated contacts/custom_attributes controller class and routes


### PR DESCRIPTION
# Pull Request

## Description

This PR updates the `contactable_inboxes` endpoint to **only return WhatsApp-related inboxes**.

Previously, the API response included all accessible inbox types (Web Widget, Instagram, etc.), which caused non-WhatsApp channels to appear in contexts where only WhatsApp communication is relevant.

### What was changed
- Added filtering logic to return **WhatsApp inboxes only**
- Supported both:
  - `Channel::WhatsappUnofficial`
  - `Channel::TwilioSms` with `medium = whatsapp`
- Existing authorization (`policy.show?`) remains unchanged

### Motivation / Context
This change is required to ensure that downstream consumers (UI / integrations) only receive WhatsApp inboxes, avoiding incorrect channel selection and improving data relevance.

Fixes # (if applicable)

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

---

## How Has This Been Tested?

- Tested locally by calling: GET /api/v1/accounts/:account_id/contacts/:contact_id/contactable_inboxes
- Verified response payload only includes:
- `Channel::WhatsappUnofficial`
- `Channel::TwilioSms` with `medium = whatsapp`
- Confirmed non-WhatsApp channels (WebWidget, Instagram, etc.) are excluded
- Existing request specs continue to pass

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

