### PR TITLE
fix: include API key when calling langgraph oauth endpoints

### DIFF
--- a/app/controllers/api/v2/accounts/google_sheets_export_controller.rb
+++ b/app/controllers/api/v2/accounts/google_sheets_export_controller.rb
@@ -20,13 +20,13 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
   def status
     # Send GET request to check authorization status
     api_endpoint = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
-    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
     status_url = "#{api_endpoint}/#{Current.account.id}/status"
 
     begin
       response = HTTParty.get(
         status_url,
-        headers: { 'X-API-Key' => base_url }
+        headers: { 'X-API-Key' => api_key }
       )
 
       if response.success?
@@ -70,6 +70,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
 
     # Build external API URL
     base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
 
     return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
 
@@ -83,7 +84,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
         body: payload.to_json,
         headers: {
           'Content-Type' => 'application/json',
-          'X-API-Key' => base_url
+          'X-API-Key' => api_key
         }
       )
 
@@ -165,7 +166,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
     return render json: { error: 'Missing required parameter: account_id' }, status: :bad_request unless account_id
 
     base_api_url = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
-    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
     return render json: { error: 'EXTERNAL_TOKEN_API_URL not configured' }, status: :service_unavailable unless base_api_url
 
     # Replace base path and append `/disconnect`
@@ -178,7 +179,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
         target_url,
         headers: {
           'Content-Type' => 'application/json',
-          'X-API-Key' => base_url
+          'X-API-Key' => api_key
         },
         timeout: 15
       )
@@ -231,6 +232,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
 
     # Build external API URL
     base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
 
     return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
 
@@ -244,7 +246,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
         body: payload.to_json,
         headers: {
           'Content-Type' => 'application/json',
-          'X-API-Key' => base_url
+          'X-API-Key' => api_key
         }
       )
 
@@ -305,7 +307,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
 
     # Build external API URL
     base_api_url = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
-    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
     return render json: { error: 'EXTERNAL_TOKEN_API_URL not configured' }, status: :service_unavailable unless base_api_url
 
     # Replace the base path and append `/spreadsheet`
@@ -317,7 +319,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
         target_url,
         headers: {
           'Content-Type' => 'application/json',
-          'X-API-Key' => base_url
+          'X-API-Key' => api_key
         },
         body: payload.to_json,
         timeout: 10
@@ -446,6 +448,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
     end
 
     base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
 
     return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
 
@@ -460,7 +463,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
       }.to_json,
       headers: {
         'Content-Type' => 'application/json',
-        'X-API-Key' => base_url
+        'X-API-Key' => api_key
       }
     )
 
@@ -486,6 +489,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
 
     # Build external API URL
     base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
 
     return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
 
@@ -499,7 +503,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
         body: payload.to_json,
         headers: {
           'Content-Type' => 'application/json',
-          'X-API-Key' => base_url
+          'X-API-Key' => api_key
         }
       )
 

--- a/app/controllers/api/v2/accounts/google_sheets_export_controller.rb
+++ b/app/controllers/api/v2/accounts/google_sheets_export_controller.rb
@@ -20,10 +20,14 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
   def status
     # Send GET request to check authorization status
     api_endpoint = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
     status_url = "#{api_endpoint}/#{Current.account.id}/status"
 
     begin
-      response = HTTParty.get(status_url)
+      response = HTTParty.get(
+        status_url,
+        headers: { 'X-API-Key' => api_key }
+      )
 
       if response.success?
         authorized = response.parsed_response['authorized'] || false
@@ -162,6 +166,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
     return render json: { error: 'Missing required parameter: account_id' }, status: :bad_request unless account_id
 
     base_api_url = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
     return render json: { error: 'EXTERNAL_TOKEN_API_URL not configured' }, status: :service_unavailable unless base_api_url
 
     # Replace base path and append `/disconnect`
@@ -172,7 +177,10 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
     begin
       response = HTTParty.delete(
         target_url,
-        headers: { 'Content-Type' => 'application/json' },
+        headers: {
+          'Content-Type' => 'application/json',
+          'X-API-Key' => api_key
+        },
         timeout: 15
       )
 
@@ -299,6 +307,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
 
     # Build external API URL
     base_api_url = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
     return render json: { error: 'EXTERNAL_TOKEN_API_URL not configured' }, status: :service_unavailable unless base_api_url
 
     # Replace the base path and append `/spreadsheet`
@@ -308,7 +317,10 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
     begin
       response = HTTParty.post(
         target_url,
-        headers: { 'Content-Type' => 'application/json' },
+        headers: {
+          'Content-Type' => 'application/json',
+          'X-API-Key' => api_key
+        },
         body: payload.to_json,
         timeout: 10
       )

--- a/app/controllers/api/v2/accounts/google_sheets_export_controller.rb
+++ b/app/controllers/api/v2/accounts/google_sheets_export_controller.rb
@@ -20,13 +20,13 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
   def status
     # Send GET request to check authorization status
     api_endpoint = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
-    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
+    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
     status_url = "#{api_endpoint}/#{Current.account.id}/status"
 
     begin
       response = HTTParty.get(
         status_url,
-        headers: { 'X-API-Key' => api_key }
+        headers: { 'X-API-Key' => base_url }
       )
 
       if response.success?
@@ -70,7 +70,6 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
 
     # Build external API URL
     base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
-    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
 
     return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
 
@@ -84,7 +83,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
         body: payload.to_json,
         headers: {
           'Content-Type' => 'application/json',
-          'X-API-Key' => api_key
+          'X-API-Key' => base_url
         }
       )
 
@@ -166,7 +165,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
     return render json: { error: 'Missing required parameter: account_id' }, status: :bad_request unless account_id
 
     base_api_url = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
-    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
+    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
     return render json: { error: 'EXTERNAL_TOKEN_API_URL not configured' }, status: :service_unavailable unless base_api_url
 
     # Replace base path and append `/disconnect`
@@ -179,7 +178,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
         target_url,
         headers: {
           'Content-Type' => 'application/json',
-          'X-API-Key' => api_key
+          'X-API-Key' => base_url
         },
         timeout: 15
       )
@@ -232,7 +231,6 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
 
     # Build external API URL
     base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
-    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
 
     return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
 
@@ -246,7 +244,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
         body: payload.to_json,
         headers: {
           'Content-Type' => 'application/json',
-          'X-API-Key' => api_key
+          'X-API-Key' => base_url
         }
       )
 
@@ -307,7 +305,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
 
     # Build external API URL
     base_api_url = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
-    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
+    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
     return render json: { error: 'EXTERNAL_TOKEN_API_URL not configured' }, status: :service_unavailable unless base_api_url
 
     # Replace the base path and append `/spreadsheet`
@@ -319,7 +317,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
         target_url,
         headers: {
           'Content-Type' => 'application/json',
-          'X-API-Key' => api_key
+          'X-API-Key' => base_url
         },
         body: payload.to_json,
         timeout: 10
@@ -448,7 +446,6 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
     end
 
     base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
-    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
 
     return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
 
@@ -463,7 +460,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
       }.to_json,
       headers: {
         'Content-Type' => 'application/json',
-        'X-API-Key' => api_key
+        'X-API-Key' => base_url
       }
     )
 
@@ -489,7 +486,6 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
 
     # Build external API URL
     base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
-    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
 
     return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
 
@@ -503,7 +499,7 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
         body: payload.to_json,
         headers: {
           'Content-Type' => 'application/json',
-          'X-API-Key' => api_key
+          'X-API-Key' => base_url
         }
       )
 

--- a/app/controllers/api/v2/callback_controller.rb
+++ b/app/controllers/api/v2/callback_controller.rb
@@ -89,7 +89,7 @@ class Api::V2::CallbackController < ApplicationController
     require 'json'
 
     api_endpoint = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
-    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
     return if api_endpoint.blank?
 
     begin

--- a/app/controllers/api/v2/callback_controller.rb
+++ b/app/controllers/api/v2/callback_controller.rb
@@ -89,7 +89,7 @@ class Api::V2::CallbackController < ApplicationController
     require 'json'
 
     api_endpoint = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
-    api_key = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
     return if api_endpoint.blank?
 
     begin

--- a/app/controllers/api/v2/callback_controller.rb
+++ b/app/controllers/api/v2/callback_controller.rb
@@ -89,6 +89,7 @@ class Api::V2::CallbackController < ApplicationController
     require 'json'
 
     api_endpoint = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
     return if api_endpoint.blank?
 
     begin
@@ -96,7 +97,10 @@ class Api::V2::CallbackController < ApplicationController
       http = Net::HTTP.new(api_url.host, api_url.port)
       http.use_ssl = (api_url.scheme == 'https')
 
-      request = Net::HTTP::Post.new(api_url.request_uri, { 'Content-Type' => 'application/json' })
+      request = Net::HTTP::Post.new(api_url.request_uri, {
+        'Content-Type' => 'application/json',
+        'X-API-Key' => api_key
+      })
       payload = {
         access_token: access_token['access_token'],
         refresh_token: access_token['refresh_token'],


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a **401 Unauthorized** error when Chatwoot calls `jangkau.langgraph` OAuth endpoints after API key enforcement.

Previously, Chatwoot did not include the required `X-API-Key` header when calling external `jangkau.langgraph` APIs. After recent authentication hardening on the langgraph side, these requests began failing.

This change adds the `X-API-Key` header (from `JANGKAU_AGENT_API_KEY`) to all relevant outbound requests from Chatwoot.

---

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

---

## How Has This Been Tested?

* Reproduced the issue by completing the Google OAuth flow and observing a 401 response from `jangkau.langgraph`
* Verified that after the change:

  * OAuth token exchange completes successfully
  * All affected API calls return 200 responses
* Tested locally with `JANGKAU_AGENT_API_KEY` set in the environment

---

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented on my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules