### PR TITLE
refactor: standardize API base URL to JANGKAU_AGENT_API_URL

### DIFF
--- a/app/controllers/api/v2/accounts/google_sheets_export_controller.rb
+++ b/app/controllers/api/v2/accounts/google_sheets_export_controller.rb
@@ -19,9 +19,11 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
 
   def status
     # Send GET request to check authorization status
-    api_endpoint = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
+    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
     api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
-    status_url = "#{api_endpoint}/#{Current.account.id}/status"
+    return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
+
+    status_url = "#{base_url}v2/oauth/google/credentials/#{Current.account.id}/status"
 
     begin
       response = HTTParty.get(
@@ -165,14 +167,11 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
     account_id = params[:account_id]
     return render json: { error: 'Missing required parameter: account_id' }, status: :bad_request unless account_id
 
-    base_api_url = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
+    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
     api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
-    return render json: { error: 'EXTERNAL_TOKEN_API_URL not configured' }, status: :service_unavailable unless base_api_url
+    return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
 
-    # Replace base path and append `/disconnect`
-    # Example: http://0.0.0.0:8080/v2/oauth/google/credentials
-    # → http://0.0.0.0:8080/v2/oauth/google/credentials/{account_id}/disconnect
-    target_url = base_api_url.gsub(%r{/v2/oauth/google/.*}, "/v2/oauth/google/credentials/#{account_id}/disconnect")
+    target_url = "#{base_url}v2/oauth/google/credentials/#{account_id}/disconnect"
 
     begin
       response = HTTParty.delete(
@@ -306,13 +305,11 @@ class Api::V2::Accounts::GoogleSheetsExportController < Api::V1::Accounts::BaseC
     end
 
     # Build external API URL
-    base_api_url = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
+    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
     api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
-    return render json: { error: 'EXTERNAL_TOKEN_API_URL not configured' }, status: :service_unavailable unless base_api_url
+    return render json: { error: 'JANGKAU_AGENT_API_URL not configured' }, status: :service_unavailable unless base_url
 
-    # Replace the base path and append `/spreadsheet`
-    # Example: http://0.0.0.0:8080/v2/oauth/google/credentials → http://0.0.0.0:8080/v2/oauth/google/spreadsheet
-    target_url = base_api_url.gsub(%r{/v2/oauth/google/.*}, '/v2/oauth/google/spreadsheet')
+    target_url = "#{base_url}v2/oauth/google/spreadsheet"
 
     begin
       response = HTTParty.post(

--- a/app/controllers/api/v2/callback_controller.rb
+++ b/app/controllers/api/v2/callback_controller.rb
@@ -88,12 +88,12 @@ class Api::V2::CallbackController < ApplicationController
     require 'net/http'
     require 'json'
 
-    api_endpoint = GlobalConfigService.load('EXTERNAL_TOKEN_API_URL', nil)
+    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
     api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
-    return if api_endpoint.blank?
+    return if base_url.blank?
 
     begin
-      api_url = URI.parse(api_endpoint)
+      api_url = URI.parse("#{base_url}v2/oauth/google/credentials")
       http = Net::HTTP.new(api_url.host, api_url.port)
       http.use_ssl = (api_url.scheme == 'https')
 


### PR DESCRIPTION
# Pull Request Template

## Description

Standardize API configuration by using `JANGKAU_AGENT_API_URL` as the single source of truth for the base URL.
Previously, `EXTERNAL_TOKEN_API_URL` contained a full endpoint path, while `JANGKAU_AGENT_API_URL` was intended to be a pure base URL, leading to confusion.

This PR rechecks and ensures that:

* All API endpoints are derived from `JANGKAU_AGENT_API_URL`
* Paths are appended explicitly in code
* `base_url` is never set to an API key
* No unintended usage of `EXTERNAL_TOKEN_API_URL` remains

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented on my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules