### PR TITLE
feat: auto create and delete default numbering config for AI Bot

### DIFF
--- a/app/jobs/cleanup_numbering_counters_job.rb
+++ b/app/jobs/cleanup_numbering_counters_job.rb
@@ -13,7 +13,7 @@ class CleanupNumberingCountersJob < ApplicationJob
     )
 
     base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
-    api_key = ENV.fetch('JANGKAU_INTERNAL_API_KEY', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
 
     unless base_url.present?
       Rails.logger.warn('[CleanupNumberingCountersJob] JANGKAU_AGENT_API_URL not configured, skipping')
@@ -21,14 +21,14 @@ class CleanupNumberingCountersJob < ApplicationJob
     end
 
     response = HTTParty.delete(
-      "#{base_url}/v2/internal/numbering/counters",
+      "#{base_url}v2/internal/numbering/counters",
       body: {
         account_id: account_id,
         ai_agent_id: ai_agent_id
       }.to_json,
       headers: {
         'Content-Type' => 'application/json',
-        'X-Internal-Api-Key' => api_key
+        'X-API-Key' => api_key
       },
       timeout: 10
     )

--- a/app/jobs/cleanup_numbering_counters_job.rb
+++ b/app/jobs/cleanup_numbering_counters_job.rb
@@ -21,7 +21,7 @@ class CleanupNumberingCountersJob < ApplicationJob
     end
 
     response = HTTParty.delete(
-      "#{base_url}v2/internal/numbering/counters",
+      "#{base_url}v2/numbering/counters",
       body: {
         account_id: account_id,
         ai_agent_id: ai_agent_id

--- a/app/jobs/cleanup_numbering_counters_job.rb
+++ b/app/jobs/cleanup_numbering_counters_job.rb
@@ -1,0 +1,50 @@
+class CleanupNumberingCountersJob < ApplicationJob
+  queue_as :low
+
+  # Called when an AI agent is destroyed to clean up numbering counters
+  # in jangkau.langgraph database.
+  #
+  # @param account_id [Integer] The account ID
+  # @param ai_agent_id [Integer] The AI agent ID that was deleted
+  def perform(account_id, ai_agent_id)
+    Rails.logger.info(
+      "[CleanupNumberingCountersJob] Cleaning up counters for " \
+      "account=#{account_id}, ai_agent=#{ai_agent_id}"
+    )
+
+    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_INTERNAL_API_KEY', nil)
+
+    unless base_url.present?
+      Rails.logger.warn('[CleanupNumberingCountersJob] JANGKAU_AGENT_API_URL not configured, skipping')
+      return
+    end
+
+    response = HTTParty.delete(
+      "#{base_url}/v2/internal/numbering/counters",
+      body: {
+        account_id: account_id,
+        ai_agent_id: ai_agent_id
+      }.to_json,
+      headers: {
+        'Content-Type' => 'application/json',
+        'X-Internal-Api-Key' => api_key
+      },
+      timeout: 10
+    )
+
+    if response.success?
+      data = response.parsed_response
+      Rails.logger.info(
+        "[CleanupNumberingCountersJob] Successfully deleted #{data['deleted_count']} counters"
+      )
+    else
+      Rails.logger.error(
+        "[CleanupNumberingCountersJob] Failed to delete counters: #{response.code} - #{response.body}"
+      )
+    end
+  rescue StandardError => e
+    Rails.logger.error("[CleanupNumberingCountersJob] Error: #{e.message}")
+    # Don't re-raise - this is a best-effort cleanup
+  end
+end

--- a/app/models/ai_agent.rb
+++ b/app/models/ai_agent.rb
@@ -53,6 +53,8 @@ class AiAgent < ApplicationRecord
   accepts_nested_attributes_for :ai_agent_selected_labels, allow_destroy: true
 
   before_validation :set_default_messages
+  after_create :create_default_numbering_config
+  after_destroy :cleanup_numbering_counters
 
   def set_default_messages
     self.system_prompts ||= 'Default system prompt'
@@ -161,5 +163,23 @@ class AiAgent < ApplicationRecord
       'ai_agent_selected_labels' => 'selected_labels',
       'ai_agent_followups' => 'followups'
     }[key] || key
+  end
+
+  def create_default_numbering_config
+    sheet_numbering_configs.create!(
+      account: account,
+      numbering_key: 'default',
+      prefix: nil,
+      format_pattern: '[NUMBER]/[MONTH]/[YEAR]',
+      current_value: 1,
+      number_padding: 3,
+      reset_interval: 'never'
+    )
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error("[AiAgent] Failed to create default numbering config: #{e.message}")
+  end
+
+  def cleanup_numbering_counters
+    CleanupNumberingCountersJob.perform_later(account_id, id)
   end
 end


### PR DESCRIPTION
## Description

On AI Bot creation, the system now inserts a default numbering configuration into `sheet_numbering_configs`  table

On AI Bot deletion, all related numbering configuration records are automatically removed

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually created a new AI Bot and verified:
  - Default records are created in `sheet_numbering_configs`
- Deleted the AI Bot and verified: 
  - Related records are removed from table
- Confirmed no changes to existing bots or numbering behavior.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
