### PR TITLE
fix: reminder variable placeholder

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
@@ -295,7 +295,7 @@ const AVAILABLE_VARIABLES = computed(() => [
 
 const messagePreview = computed(() => {
   let text = followUpConfig.message || '';
-  AVAILABLE_VARIABLES.forEach(variable => {
+  AVAILABLE_VARIABLES.value.forEach(variable => {
     text = text.replaceAll(variable.value, `<span class="font-bold text-slate-800 dark:text-slate-100">${variable.mock}</span>`);
   });
   return text.replace(/\n/g, '<br>');


### PR DESCRIPTION
## Description

Fixes a runtime error when inserting variables in BookingBotView.
`AVAILABLE_VARIABLES` is a computed ref and was incorrectly accessed without `.value`, causing `forEach is not a function`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Opened Booking Bot config
- Clicked “Add Variable” -> choose name or date option
- Verified variables insert correctly and no console errors occur

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
