### PR TITLE
fix: gowa skip session check and add wa status

### DIFF
--- a/app/adapters/whatsapp_unofficial/gowa_adapter.rb
+++ b/app/adapters/whatsapp_unofficial/gowa_adapter.rb
@@ -50,6 +50,15 @@ module WhatsappUnofficial
       { connected: is_logged_in, status: status }
     rescue StandardError => e
       log_error "Failed to get session status for device #{channel.device_id}: #{e.message}"
+
+      # Handle DEVICE_NOT_FOUND - mark channel as disconnected to prevent future API calls
+      if e.message.include?('DEVICE_NOT_FOUND')
+        log_info "Device #{channel.device_id} not found on GOWA server, marking as disconnected"
+        channel.mark_as_disconnected!
+        channel.clear_session_status_cache
+        return { connected: false, status: 'disconnected', device_not_found: true }
+      end
+
       { connected: false, status: 'error' }
     end
 
@@ -109,6 +118,7 @@ module WhatsappUnofficial
     end
 
     # Logout session (disconnect but keep device_id)
+    # Marks channel as intentionally disconnected to prevent future session status checks
     def logout_session
       return nil unless channel.device_id.present?
 
@@ -116,17 +126,21 @@ module WhatsappUnofficial
       response = gowa_service.logout_device(device_id: channel.device_id)
       log_info "GOWA logout response for #{channel.device_id}: #{response}"
 
+      # Mark as intentionally disconnected to skip future session status checks
+      channel.mark_as_disconnected!
       channel.clear_session_status_cache
       channel.write_session_status_to_cache('not_logged_in')
 
       response
     rescue StandardError => e
       log_error "Failed to logout GOWA device #{channel.device_id}: #{e.message}"
+      channel.mark_as_disconnected!
       channel.clear_session_status_cache
       nil
     end
 
     # Disconnect session - logout and broadcast status
+    # Marks channel as intentionally disconnected to prevent future session status checks
     def disconnect_session
       return { success: false, message: 'No device configured' } unless channel.device_id.present?
 
@@ -136,16 +150,21 @@ module WhatsappUnofficial
         response = gowa_service.logout_device(device_id: channel.device_id)
         log_info "GOWA disconnect response for #{channel.device_id}: #{response}"
 
+        # Mark as intentionally disconnected to skip future session status checks
+        channel.mark_as_disconnected!
         channel.clear_session_status_cache
         channel.write_session_status_to_cache('not_logged_in')
 
         # Broadcast disconnect event
         WhatsappUnofficial::BroadcastService.new(channel).disconnect
 
-        { success: true, message: 'Session disconnected successfully', status: 'not_logged_in' }
+        { success: true, message: 'Session disconnected successfully', status: 'disconnected' }
       rescue StandardError => e
         log_error "Failed to disconnect GOWA device #{channel.device_id}: #{e.message}"
-        { success: false, message: "Failed to disconnect: #{e.message}" }
+        # Even if API fails, mark as disconnected to prevent further API calls
+        channel.mark_as_disconnected!
+        channel.clear_session_status_cache
+        { success: false, message: "Failed to disconnect: #{e.message}", status: 'disconnected' }
       end
     end
 
@@ -165,10 +184,12 @@ module WhatsappUnofficial
         # Check if reconnect was successful
         status = get_session_status
         if status[:connected]
+          channel.mark_as_connected!
           channel.write_session_status_to_cache('logged_in')
           WhatsappUnofficial::BroadcastService.new(channel).reconnect
-          { success: true, message: 'Session reconnected successfully', status: 'logged_in' }
+          { success: true, message: 'Session reconnected successfully', status: 'connected' }
         else
+          channel.mark_as_waiting!
           channel.write_session_status_to_cache('waiting')
           { success: true, message: 'Reconnect initiated, waiting for connection', status: 'waiting' }
         end
@@ -253,6 +274,7 @@ module WhatsappUnofficial
       channel.reload
 
       # Step 5: Set status for QR generation
+      channel.mark_as_waiting!
       channel.write_session_status_to_cache('waiting')
 
       {
@@ -263,6 +285,7 @@ module WhatsappUnofficial
       }
     rescue StandardError => e
       log_error "Failed to restart GOWA device for #{channel.phone_number}: #{e.message}"
+      channel.mark_as_waiting!
       channel.write_session_status_to_cache('waiting')
 
       {
@@ -288,6 +311,7 @@ module WhatsappUnofficial
 
     def handle_failed_rescan
       log_error "Maximum rescan attempts reached for #{channel.phone_number}"
+      channel.mark_as_disconnected!
       channel.write_session_status_to_cache('not_logged_in')
       logout_session
       channel.clear_rescan_attempts
@@ -315,6 +339,7 @@ module WhatsappUnofficial
       channel.reload
 
       # Set status for QR generation
+      channel.mark_as_waiting!
       channel.write_session_status_to_cache('waiting')
 
       {
@@ -332,6 +357,7 @@ module WhatsappUnofficial
     # Used when device exists but session was deleted/logged out
     def trigger_qr_login
       channel.clear_session_status_cache
+      channel.mark_as_waiting!
       channel.write_session_status_to_cache('waiting')
 
       log_info "Triggering fresh QR login for device #{channel.device_id}"

--- a/app/adapters/whatsapp_unofficial/gowa_adapter.rb
+++ b/app/adapters/whatsapp_unofficial/gowa_adapter.rb
@@ -32,31 +32,38 @@ module WhatsappUnofficial
     end
 
     # Returns: { connected: Boolean, status: String }
+    # Status values: 'connected', 'disconnected', 'waiting', 'error'
     def get_session_status
-      return { connected: false, status: 'not_logged_in' } unless channel.device_id.present?
+      return { connected: false, status: 'disconnected' } unless channel.device_id.present?
+
+      # Skip API call only if channel is explicitly disconnected by user/admin
+      if channel.disconnected?
+        log_info "Skipping session status check - channel is disconnected"
+        return { connected: false, status: 'disconnected' }
+      end
 
       result = gowa_service.get_device_status(device_id: channel.device_id)
       is_logged_in = result.dig('results', 'is_logged_in') || false
       is_connected = result.dig('results', 'is_connected') || false
 
       status = if is_logged_in
-                 'logged_in'
+                 'connected'
                elsif is_connected
-                 'waiting_for_qr'
+                 'waiting'
                else
-                 'not_logged_in'
+                 'disconnected'
                end
 
       { connected: is_logged_in, status: status }
     rescue StandardError => e
       log_error "Failed to get session status for device #{channel.device_id}: #{e.message}"
 
-      # Handle DEVICE_NOT_FOUND - mark channel as disconnected to prevent future API calls
+      # Handle DEVICE_NOT_FOUND gracefully - mark as disconnected and return disconnected
+      # This stops future API calls and allows user to start fresh reconnect flow
       if e.message.include?('DEVICE_NOT_FOUND')
-        log_info "Device #{channel.device_id} not found on GOWA server, marking as disconnected"
+        log_info "Device #{channel.device_id} not found, marking channel as disconnected"
         channel.mark_as_disconnected!
-        channel.clear_session_status_cache
-        return { connected: false, status: 'disconnected', device_not_found: true }
+        return { connected: false, status: 'disconnected' }
       end
 
       { connected: false, status: 'error' }
@@ -129,7 +136,7 @@ module WhatsappUnofficial
       # Mark as intentionally disconnected to skip future session status checks
       channel.mark_as_disconnected!
       channel.clear_session_status_cache
-      channel.write_session_status_to_cache('not_logged_in')
+      channel.write_session_status_to_cache('disconnected')
 
       response
     rescue StandardError => e
@@ -153,7 +160,7 @@ module WhatsappUnofficial
         # Mark as intentionally disconnected to skip future session status checks
         channel.mark_as_disconnected!
         channel.clear_session_status_cache
-        channel.write_session_status_to_cache('not_logged_in')
+        channel.write_session_status_to_cache('disconnected')
 
         # Broadcast disconnect event
         WhatsappUnofficial::BroadcastService.new(channel).disconnect
@@ -185,7 +192,7 @@ module WhatsappUnofficial
         status = get_session_status
         if status[:connected]
           channel.mark_as_connected!
-          channel.write_session_status_to_cache('logged_in')
+          channel.write_session_status_to_cache('connected')
           WhatsappUnofficial::BroadcastService.new(channel).reconnect
           { success: true, message: 'Session reconnected successfully', status: 'connected' }
         else
@@ -312,7 +319,7 @@ module WhatsappUnofficial
     def handle_failed_rescan
       log_error "Maximum rescan attempts reached for #{channel.phone_number}"
       channel.mark_as_disconnected!
-      channel.write_session_status_to_cache('not_logged_in')
+      channel.write_session_status_to_cache('disconnected')
       logout_session
       channel.clear_rescan_attempts
 

--- a/app/adapters/whatsapp_unofficial/waha_adapter.rb
+++ b/app/adapters/whatsapp_unofficial/waha_adapter.rb
@@ -24,14 +24,18 @@ module WhatsappUnofficial
     end
 
     # Returns: { connected: Boolean, status: String }
+    # Status values: 'connected', 'disconnected', 'waiting', 'error'
     def get_session_status
-      return { connected: false, status: 'not_logged_in' } unless channel.token.present?
+      return { connected: false, status: 'disconnected' } unless channel.token.present?
 
       result = waha_service.get_session_status(api_key: channel.token)
-      waha_status = result.dig('data', 'status') || 'not_logged_in'
+      waha_status = result.dig('data', 'status') || 'disconnected'
       connected = waha_status.downcase == 'logged_in'
 
-      { connected: connected, status: waha_status }
+      # Normalize WAHA status to standard terminology
+      normalized_status = connected ? 'connected' : 'disconnected'
+
+      { connected: connected, status: normalized_status }
     rescue StandardError => e
       log_error "Failed to get session status for #{channel.phone_number}: #{e.message}"
       { connected: false, status: 'error' }
@@ -201,7 +205,7 @@ module WhatsappUnofficial
     def handle_failed_rescan
       log_error "Maximum rescan attempts reached for #{channel.phone_number}"
       channel.mark_as_disconnected!
-      channel.write_session_status_to_cache('not_logged_in')
+      channel.write_session_status_to_cache('disconnected')
       logout_session
       channel.clear_rescan_attempts
 

--- a/app/adapters/whatsapp_unofficial/waha_adapter.rb
+++ b/app/adapters/whatsapp_unofficial/waha_adapter.rb
@@ -70,6 +70,7 @@ module WhatsappUnofficial
     end
 
     # Logout and clear token
+    # Marks channel as intentionally disconnected to prevent future session status checks
     def logout_session
       return nil unless channel.token.present?
 
@@ -77,12 +78,15 @@ module WhatsappUnofficial
       response = waha_service.logout_session(api_key: channel.token)
       log_info "WAHA session logout response for #{channel.phone_number}: #{response}"
 
+      # Mark as intentionally disconnected to skip future session status checks
+      channel.mark_as_disconnected!
       channel.update!(token: nil)
       channel.clear_session_status_cache
 
       response
     rescue StandardError => e
       log_error "Failed to logout WAHA session for #{channel.phone_number}: #{e.message}"
+      channel.mark_as_disconnected!
       channel.update!(token: nil)
       channel.clear_session_status_cache
       nil
@@ -154,6 +158,7 @@ module WhatsappUnofficial
       end
 
       # Step 6: Set status for QR generation
+      channel.mark_as_waiting!
       channel.write_session_status_to_cache('waiting')
 
       # Step 7: Clear QR cache
@@ -169,6 +174,7 @@ module WhatsappUnofficial
       }
     rescue StandardError => e
       log_error "Failed to complete restart for #{channel.phone_number}: #{e.message}"
+      channel.mark_as_waiting!
       channel.write_session_status_to_cache('waiting')
 
       {
@@ -194,6 +200,7 @@ module WhatsappUnofficial
 
     def handle_failed_rescan
       log_error "Maximum rescan attempts reached for #{channel.phone_number}"
+      channel.mark_as_disconnected!
       channel.write_session_status_to_cache('not_logged_in')
       logout_session
       channel.clear_rescan_attempts

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -79,7 +79,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController #
         render json: {
           success: true,
           already_connected: true,
-          status: 'logged_in',
+          status: 'connected',
           provider: @channel.effective_provider,
           message: 'WhatsApp session is already connected'
         }

--- a/app/controllers/waha/callback_controller.rb
+++ b/app/controllers/waha/callback_controller.rb
@@ -182,7 +182,7 @@ class Waha::CallbackController < ApplicationController # rubocop:disable Metrics
                                    type: 'session_status_changed',
                                    status: status,
                                    phone_number: channel.phone_number,
-                                   connected: status == 'logged_in',
+                                   connected: %w[logged_in connected].include?(status),
                                    inbox_id: inbox.id,
                                    channel_id: channel.id,
                                    account_id: account.id,
@@ -210,7 +210,7 @@ class Waha::CallbackController < ApplicationController # rubocop:disable Metrics
     ActionCable.server.broadcast(pubsub_token, {
                                    event: 'whatsapp_status_changed',
                                    type: 'session_ready',
-                                   status: 'logged_in',
+                                   status: 'connected',
                                    phone_number: channel.phone_number,
                                    connected: true,
                                    message: 'WhatsApp session is ready for messaging!',
@@ -296,7 +296,7 @@ class Waha::CallbackController < ApplicationController # rubocop:disable Metrics
     ActionCable.server.broadcast(pubsub_token, {
                                    event: 'whatsapp_status_changed',
                                    type: 'phone_validation_success',
-                                   status: 'logged_in',
+                                   status: 'connected',
                                    phone_number: channel.phone_number,
                                    session_id: session_id,
                                    connected: true,

--- a/app/models/channel/whatsapp_unofficial.rb
+++ b/app/models/channel/whatsapp_unofficial.rb
@@ -97,9 +97,9 @@ class Channel::WhatsappUnofficial < ApplicationRecord
     status == STATUS_CONNECTED
   end
 
-  # Check if the channel was intentionally disconnected by user/admin
-  # and should not attempt session status checks
-  def intentionally_disconnected?
+  # Check if the channel is disconnected (user/admin initiated or device not found)
+  # When true, session status checks should be skipped
+  def disconnected?
     status == STATUS_DISCONNECTED
   end
 
@@ -278,7 +278,7 @@ class Channel::WhatsappUnofficial < ApplicationRecord
   def handle_max_validation_attempts_reached(current_attempts, max_attempts)
     Rails.logger.error "Maximum attempts reached for #{phone_number}."
 
-    write_session_status_to_cache('not_logged_in')
+    write_session_status_to_cache('disconnected')
     disconnect_waha_session
     clear_mismatch_attempts
 

--- a/app/models/channel/whatsapp_unofficial.rb
+++ b/app/models/channel/whatsapp_unofficial.rb
@@ -8,6 +8,7 @@
 #  phone_number    :string           not null
 #  provider        :string
 #  provider_config :jsonb
+#  status          :string           default("disconnected"), not null
 #  token           :string
 #  webhook_url     :string
 #  created_at      :datetime         not null
@@ -19,6 +20,7 @@
 #
 #  index_channel_whatsapp_unofficials_on_account_id    (account_id)
 #  index_channel_whatsapp_unofficials_on_phone_number  (phone_number) UNIQUE
+#  index_channel_whatsapp_unofficials_on_status        (status)
 #
 
 class Channel::WhatsappUnofficial < ApplicationRecord
@@ -31,10 +33,18 @@ class Channel::WhatsappUnofficial < ApplicationRecord
   EDITABLE_ATTRS = [:token, :device_id, :phone_number, :provider, { provider_config: {} }].freeze
   PROVIDERS = %w[waha gowa].freeze
 
+  # Connection status values stored in the database
+  # These represent the user-facing connection state
+  STATUS_CONNECTED = 'connected'
+  STATUS_DISCONNECTED = 'disconnected'
+  STATUS_WAITING = 'waiting' # Waiting for QR scan
+  STATUSES = [STATUS_CONNECTED, STATUS_DISCONNECTED, STATUS_WAITING].freeze
+
   validates :phone_number, presence: true
   validates :account_id, presence: true
   validates :webhook_url, length: { maximum: Limits::URL_LENGTH_LIMIT }
   validates :provider, inclusion: { in: PROVIDERS }, allow_nil: true
+  validates :status, inclusion: { in: STATUSES }
 
   belongs_to :account
   has_one :inbox, as: :channel, dependent: :destroy
@@ -77,6 +87,44 @@ class Channel::WhatsappUnofficial < ApplicationRecord
 
   # Legacy alias for backward compatibility
   alias waha_configured? provider_configured?
+
+  # ============================================================================
+  # Connection Status Management
+  # ============================================================================
+
+  # Check if the channel is currently connected
+  def connected?
+    status == STATUS_CONNECTED
+  end
+
+  # Check if the channel was intentionally disconnected by user/admin
+  # and should not attempt session status checks
+  def intentionally_disconnected?
+    status == STATUS_DISCONNECTED
+  end
+
+  # Check if the channel is waiting for QR scan
+  def waiting_for_qr?
+    status == STATUS_WAITING
+  end
+
+  # Update status to connected
+  def mark_as_connected!
+    update!(status: STATUS_CONNECTED)
+    Rails.logger.info "Channel #{phone_number} marked as connected"
+  end
+
+  # Update status to disconnected (user/admin initiated)
+  def mark_as_disconnected!
+    update!(status: STATUS_DISCONNECTED)
+    Rails.logger.info "Channel #{phone_number} marked as disconnected"
+  end
+
+  # Update status to waiting for QR scan
+  def mark_as_waiting!
+    update!(status: STATUS_WAITING)
+    Rails.logger.info "Channel #{phone_number} marked as waiting for QR"
+  end
 
   # ============================================================================
   # Service Delegations

--- a/app/models/concerns/whatsapp_unofficial/cacheable.rb
+++ b/app/models/concerns/whatsapp_unofficial/cacheable.rb
@@ -118,25 +118,28 @@ module WhatsappUnofficial
     end
 
     # Cached session status with interpretation
+    # Status values: 'connected', 'disconnected', 'waiting', 'mismatch', 'failed'
     def session_status
       Rails.logger.info "Checking session status for #{phone_number} using cache"
 
-      return { 'data' => { 'connected' => false, 'status' => 'not_logged_in' } } if token.blank? && device_id.blank?
+      return { 'data' => { 'connected' => false, 'status' => 'disconnected' } } if token.blank? && device_id.blank?
 
       cached_status = read_session_status_from_cache
       Rails.logger.info "CACHE: Read '#{cached_status}' for #{phone_number}"
 
       case cached_status
-      when 'validated'
-        { 'data' => { 'connected' => true, 'status' => 'logged_in' } }
+      when 'validated', 'connected'
+        { 'data' => { 'connected' => true, 'status' => 'connected' } }
       when 'mismatch'
         { 'data' => { 'connected' => false, 'status' => 'mismatch' } }
       when 'waiting'
-        { 'data' => { 'connected' => false, 'status' => 'waiting_for_qr' } }
+        { 'data' => { 'connected' => false, 'status' => 'waiting' } }
       when 'failed'
         { 'data' => { 'connected' => false, 'status' => 'failed' } }
+      when 'disconnected'
+        { 'data' => { 'connected' => false, 'status' => 'disconnected' } }
       else
-        { 'data' => { 'connected' => false, 'status' => 'pending_validation' } }
+        { 'data' => { 'connected' => false, 'status' => 'disconnected' } }
       end
     end
   end

--- a/app/services/waha/status_changed_service.rb
+++ b/app/services/waha/status_changed_service.rb
@@ -29,7 +29,7 @@ class Waha::StatusChangedService
     event_data = {
       event: 'whatsapp_status_changed',
       type: 'phone_validation_success',
-      status: 'logged_in',
+      status: 'connected',
       phone_number: channel.phone_number,
       session_id: params[:sessionID],
       connected: true,

--- a/app/services/whatsapp_unofficial/phone_validation_service.rb
+++ b/app/services/whatsapp_unofficial/phone_validation_service.rb
@@ -88,6 +88,7 @@ class WhatsappUnofficial::PhoneValidationService
 
   def handle_match
     Rails.logger.info 'Phone validation SUCCESS - numbers match!'
+    channel.mark_as_connected!
     channel.clear_mismatch_attempts
     channel.clear_rescan_attempts
     channel.write_session_status_to_cache('validated')
@@ -114,6 +115,7 @@ class WhatsappUnofficial::PhoneValidationService
 
   def handle_max_attempts_reached(current_attempts, is_rescan)
     Rails.logger.error "Maximum mismatch attempts (#{MAX_ATTEMPTS}) reached for #{channel.phone_number}"
+    channel.mark_as_disconnected!
     channel.write_session_status_to_cache('failed', expires_in: 1.hour)
     channel.disconnect_waha_session
     broadcast_service.session_failed(callback_phone, current_attempts)

--- a/app/services/whatsapp_unofficial/qr_code_service.rb
+++ b/app/services/whatsapp_unofficial/qr_code_service.rb
@@ -60,16 +60,19 @@ class WhatsappUnofficial::QrCodeService
 
   def handle_already_logged_in
     Rails.logger.info "Device #{channel.phone_number} is already logged in, updating status"
+    channel.mark_as_connected!
     channel.write_session_status_to_cache('validated')
     channel.clear_mismatch_attempts
     channel.clear_rescan_attempts
     broadcast_service.session_ready
 
-    { 'data' => { 'already_connected' => true, 'status' => 'logged_in' } }
+    { 'data' => { 'already_connected' => true, 'status' => 'connected' } }
   end
 
   def handle_success(qr_result)
     Rails.logger.info "QR code generated successfully for phone #{channel.phone_number}"
+    # Mark channel as waiting for QR scan if not already connected
+    channel.mark_as_waiting! unless channel.connected?
     { 'data' => { 'qr' => qr_result[:qr_data], 'qr_type' => qr_result[:qr_type].to_s } }
   end
 

--- a/app/services/whatsapp_unofficial/session_status_service.rb
+++ b/app/services/whatsapp_unofficial/session_status_service.rb
@@ -9,11 +9,27 @@ class WhatsappUnofficial::SessionStatusService
 
   # Check real-time session status from provider API
   # Handles state transitions and broadcasts events
+  # Skips API calls for intentionally disconnected channels to prevent DEVICE_NOT_FOUND errors
   # @return [Hash] Response with connection status
   def perform
     Rails.logger.info "Checking real-time status for #{channel.phone_number} from #{channel.effective_provider} API"
 
     return not_logged_in_response unless channel.provider_configured?
+
+    # Skip API calls if device_id is missing for GOWA provider
+    if channel.effective_provider == 'gowa' && channel.device_id.blank?
+      Rails.logger.info "Skipping session status check for #{channel.phone_number} - no device_id configured"
+      return not_logged_in_response
+    end
+
+    # Skip API calls if channel is marked as disconnected
+    # This prevents unnecessary DEVICE_NOT_FOUND errors for devices that were:
+    # - Intentionally disconnected by user/admin
+    # - Previously found to not exist on the provider server
+    if channel.intentionally_disconnected?
+      Rails.logger.info "Skipping session status check for #{channel.phone_number} - channel is marked as disconnected"
+      return disconnected_response
+    end
 
     check_status_with_transitions
   rescue StandardError => e
@@ -41,7 +57,8 @@ class WhatsappUnofficial::SessionStatusService
   end
 
   def handle_connected(_previous_status)
-    Rails.logger.info "Session connected for #{channel.phone_number}, updating cache to 'validated'"
+    Rails.logger.info "Session connected for #{channel.phone_number}, updating status to 'connected'"
+    channel.mark_as_connected!
     channel.write_session_status_to_cache('validated')
     channel.clear_mismatch_attempts
     channel.clear_rescan_attempts
@@ -84,6 +101,10 @@ class WhatsappUnofficial::SessionStatusService
 
   def not_logged_in_response
     { 'data' => { 'connected' => false, 'status' => 'not_logged_in' } }
+  end
+
+  def disconnected_response
+    { 'data' => { 'connected' => false, 'status' => 'disconnected' } }
   end
 
   def broadcast_service

--- a/app/services/whatsapp_unofficial/session_status_service.rb
+++ b/app/services/whatsapp_unofficial/session_status_service.rb
@@ -22,13 +22,10 @@ class WhatsappUnofficial::SessionStatusService
       return not_logged_in_response
     end
 
-    # Skip API calls if channel is marked as disconnected
-    # This prevents unnecessary DEVICE_NOT_FOUND errors for devices that were:
-    # - Intentionally disconnected by user/admin
-    # - Previously found to not exist on the provider server
-    if channel.intentionally_disconnected?
-      Rails.logger.info "Skipping session status check for #{channel.phone_number} - channel is marked as disconnected"
-      return disconnected_response
+    # Skip API calls only if channel is explicitly disconnected by user/admin
+    if channel.disconnected?
+      Rails.logger.info "Skipping session status check for #{channel.phone_number} - channel is disconnected"
+      return not_logged_in_response
     end
 
     check_status_with_transitions
@@ -94,18 +91,17 @@ class WhatsappUnofficial::SessionStatusService
     {
       'data' => {
         'connected' => connected,
-        'status' => connected ? 'logged_in' : 'not_logged_in'
+        'status' => connected ? 'connected' : 'disconnected'
       }
     }
-  end
-
-  def not_logged_in_response
-    { 'data' => { 'connected' => false, 'status' => 'not_logged_in' } }
   end
 
   def disconnected_response
     { 'data' => { 'connected' => false, 'status' => 'disconnected' } }
   end
+
+  # Alias for backward compatibility
+  alias not_logged_in_response disconnected_response
 
   def broadcast_service
     @broadcast_service ||= WhatsappUnofficial::BroadcastService.new(channel)

--- a/db/migrate/20260114024932_add_status_to_channel_whatsapp_unofficials.rb
+++ b/db/migrate/20260114024932_add_status_to_channel_whatsapp_unofficials.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddStatusToChannelWhatsappUnofficials < ActiveRecord::Migration[7.0]
+  def change
+    add_column :channel_whatsapp_unofficials, :status, :string, default: 'disconnected', null: false
+
+    add_index :channel_whatsapp_unofficials, :status
+  end
+end


### PR DESCRIPTION
## Description

Add `status` column to `channel_whatsapp_unofficials` table to track WhatsApp connection state and prevent unnecessary `DEVICE_NOT_FOUND` errors when calling `/app/status` API.

**Problem:** The system was attempting to fetch session status even when devices were intentionally disconnected or no longer exist on the GOWA server, resulting in repeated `DEVICE_NOT_FOUND` errors.

**Solution:**
- Add `status` column (`connected`, `disconnected`, `waiting`) as source of truth
- Skip session status API calls for channels marked as `disconnected`
- Auto-mark channel as `disconnected` when `DEVICE_NOT_FOUND` error is received
- Update status appropriately on connect/disconnect/reconnect actions

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Delete device from GOWA admin panel / disconnect from main page
2. Visit WhatsApp Status tab or Linked Platform page
3. First request receives `DEVICE_NOT_FOUND`, channel marked as disconnected
4. Subsequent requests skip API call and return disconnected status immediately
5. Click "Reconnect" to recreate device and scan QR

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
