### PR TITLE
fix: textarea height gap and add upload max file size warning

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/components/MessageEditor.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/MessageEditor.vue
@@ -75,7 +75,10 @@ const replaceText = async message => {
 </script>
 
 <template>
-  <div class="flex-1 h-full" :class="[!hasAttachments && 'min-h-[200px]']">
+  <div
+    class="flex flex-col flex-1"
+    :class="[!hasAttachments && 'min-h-[200px]']"
+  >
     <template v-if="isEmailOrWebWidgetInbox">
       <Editor
         v-model="modelValue"
@@ -98,7 +101,7 @@ const replaceText = async message => {
         :placeholder="
           t('COMPOSE_NEW_CONVERSATION.FORM.MESSAGE_EDITOR.PLACEHOLDER')
         "
-        class="!px-0 [&>div]:!px-4 [&>div]:!border-transparent [&>div]:!bg-transparent"
+        class="!px-0 flex-1 [&>div]:!px-4 [&>div]:!border-transparent [&>div]:!bg-transparent [&>div]:flex-1 [&_textarea]:flex-1 [&_textarea]:!max-h-none"
         :custom-text-area-class="
           hasErrors
             ? 'placeholder:!text-n-ruby-9 dark:placeholder:!text-n-ruby-9'

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -35,7 +35,7 @@ export const CONVERSATION_PRIORITY_ORDER = {
 };
 
 // Size in mega bytes
-export const MAXIMUM_FILE_UPLOAD_SIZE = 40;
+export const MAXIMUM_FILE_UPLOAD_SIZE = 50;
 export const MAXIMUM_FILE_UPLOAD_SIZE_TWILIO_SMS_CHANNEL = 5;
 
 export const ALLOWED_FILE_TYPES =


### PR DESCRIPTION
## Description

Fixes textarea height not filling its container in new conversations via Contact menu and adds a warning when uploading files larger than 50MB.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Textarea height fix
1. Create a new conversation via Contact menu
2. Verify the message textarea fills its parent height

Upload size warning
1. Open conversation page
2. Try to upload a file larger than 50MB
3. Verify a warning popup appears indicating the upload size limit

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
