### PR TITLE
fix: numbering config feature

### DIFF
--- a/app/controllers/api/v2/accounts/sheet_numbering_configs_controller.rb
+++ b/app/controllers/api/v2/accounts/sheet_numbering_configs_controller.rb
@@ -38,7 +38,7 @@ class Api::V2::Accounts::SheetNumberingConfigsController < Api::V1::Accounts::Ba
   end
 
   def numbering_key_param
-    params[:numbering_key] || 'default'
+    params[:numbering_key] || params.dig(:sheet_numbering_config, :numbering_key) || 'default'
   end
 
   def sheet_numbering_config_response
@@ -52,6 +52,8 @@ class Api::V2::Accounts::SheetNumberingConfigsController < Api::V1::Accounts::Ba
       numbering_key: @sheet_numbering_config.numbering_key,
       ai_agent_id: @sheet_numbering_config.ai_agent_id,
       account_id: @sheet_numbering_config.account_id,
+      last_synced_at: @sheet_numbering_config.last_synced_at,
+      last_synced_value: @sheet_numbering_config.last_synced_value,
       created_at: @sheet_numbering_config.created_at,
       updated_at: @sheet_numbering_config.updated_at
     }

--- a/app/controllers/api/v2/accounts/sheet_numbering_configs_controller.rb
+++ b/app/controllers/api/v2/accounts/sheet_numbering_configs_controller.rb
@@ -20,7 +20,10 @@ class Api::V2::Accounts::SheetNumberingConfigsController < Api::V1::Accounts::Ba
       numbering_key: numbering_key_param
     )
 
+    previous_current_value = @sheet_numbering_config.current_value
+
     if @sheet_numbering_config.update(sheet_numbering_config_params)
+      sync_counter_to_jangkau if @sheet_numbering_config.current_value != previous_current_value
       render json: sheet_numbering_config_response, status: :ok
     else
       render json: { errors: @sheet_numbering_config.errors.full_messages }, status: :unprocessable_entity
@@ -57,6 +60,15 @@ class Api::V2::Accounts::SheetNumberingConfigsController < Api::V1::Accounts::Ba
       created_at: @sheet_numbering_config.created_at,
       updated_at: @sheet_numbering_config.updated_at
     }
+  end
+
+  def sync_counter_to_jangkau
+    SyncNumberingCounterJob.perform_later(
+      @sheet_numbering_config.account_id,
+      @sheet_numbering_config.ai_agent_id,
+      @sheet_numbering_config.numbering_key,
+      @sheet_numbering_config.current_value
+    )
   end
 
   def sheet_numbering_config_params

--- a/app/controllers/api/v2/internal/sheet_numbering_configs_controller.rb
+++ b/app/controllers/api/v2/internal/sheet_numbering_configs_controller.rb
@@ -9,7 +9,7 @@ class Api::V2::Internal::SheetNumberingConfigsController < ActionController::API
   # Required params:
   #   - account_id: The account ID
   #   - ai_agent_id: The AI agent ID
-  #   - numbering_key: The numbering key (e.g., "booking", "invoice")
+  #   - numbering_key: The numbering key (e.g., "booking", "lead_generation")
   #
   # Response (200 OK):
   #   {
@@ -26,7 +26,7 @@ class Api::V2::Internal::SheetNumberingConfigsController < ActionController::API
   # Response (401 Unauthorized):
   #   - error: "Unauthorized"
   #
-  def config
+  def show_config
     Rails.logger.info("[Internal::SheetNumberingConfigs] Fetching config: #{config_params.inspect}")
 
     sheet_config = SheetNumberingConfig.find_by!(

--- a/app/controllers/api/v2/internal/sheet_numbering_configs_controller.rb
+++ b/app/controllers/api/v2/internal/sheet_numbering_configs_controller.rb
@@ -55,13 +55,13 @@ class Api::V2::Internal::SheetNumberingConfigsController < ActionController::API
   private
 
   def authenticate_api_key!
-    api_key = request.headers['X-Internal-Api-Key'] || params[:api_key]
-    expected_key = ENV.fetch('JANGKAU_INTERNAL_API_KEY', nil)
+    api_key = request.headers['X-API-Key'] || request.headers['X-Internal-Api-Key'] || params[:api_key]
+    expected_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
 
-    unless expected_key.present? && ActiveSupport::SecurityUtils.secure_compare(api_key.to_s, expected_key)
-      Rails.logger.warn('[Internal::SheetNumberingConfigs] Invalid API key')
-      render json: { error: 'Unauthorized' }, status: :unauthorized
-    end
+    return if expected_key.present? && ActiveSupport::SecurityUtils.secure_compare(api_key.to_s, expected_key)
+
+    Rails.logger.warn('[Internal::SheetNumberingConfigs] Invalid API key')
+    head :unauthorized
   end
 
   def config_params

--- a/app/controllers/api/v2/internal/sheet_numbering_configs_controller.rb
+++ b/app/controllers/api/v2/internal/sheet_numbering_configs_controller.rb
@@ -42,7 +42,9 @@ class Api::V2::Internal::SheetNumberingConfigsController < ActionController::API
       prefix: sheet_config.prefix,
       format_pattern: sheet_config.format_pattern,
       number_padding: sheet_config.number_padding,
-      numbering_key: sheet_config.numbering_key
+      numbering_key: sheet_config.numbering_key,
+      current_value: sheet_config.current_value,
+      reset_interval: sheet_config.reset_interval
     }, status: :ok
   rescue ActiveRecord::RecordNotFound => e
     Rails.logger.error("[Internal::SheetNumberingConfigs] Config not found: #{e.message}")
@@ -78,7 +80,12 @@ class Api::V2::Internal::SheetNumberingConfigsController < ActionController::API
       numbering_key: sync_params[:numbering_key] || 'default'
     )
 
-    sheet_config.update_column(:current_value, sync_params[:current_value].to_i)
+    synced_value = sync_params[:current_value].to_i
+    sheet_config.update_columns(
+      current_value: synced_value + 1,
+      last_synced_at: Time.current,
+      last_synced_value: synced_value
+    )
 
     Rails.logger.info(
       "[Internal::SheetNumberingConfigs] Counter synced: config_id=#{sheet_config.id}, " \

--- a/app/controllers/api/v2/internal/sheet_numbering_configs_controller.rb
+++ b/app/controllers/api/v2/internal/sheet_numbering_configs_controller.rb
@@ -52,6 +52,48 @@ class Api::V2::Internal::SheetNumberingConfigsController < ActionController::API
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
+  # PUT /api/v2/internal/sheet_numbering_configs/sync_counter
+  #
+  # Called by jangkau.langgraph after each counter increment to keep
+  # Chatwoot's current_value in sync with the actual counter.
+  #
+  # Required params:
+  #   - account_id: The account ID
+  #   - ai_agent_id: The AI agent ID
+  #   - numbering_key: The numbering key (defaults to 'default')
+  #   - current_value: The current counter value from jangkau
+  #
+  # Response (200 OK):
+  #   { "success": true }
+  #
+  # Response (404 Not Found):
+  #   { "error": "Config not found" }
+  #
+  def sync_counter
+    Rails.logger.info("[Internal::SheetNumberingConfigs] Syncing counter: #{sync_params.inspect}")
+
+    sheet_config = SheetNumberingConfig.find_by!(
+      account_id: sync_params[:account_id],
+      ai_agent_id: sync_params[:ai_agent_id],
+      numbering_key: sync_params[:numbering_key] || 'default'
+    )
+
+    sheet_config.update_column(:current_value, sync_params[:current_value].to_i)
+
+    Rails.logger.info(
+      "[Internal::SheetNumberingConfigs] Counter synced: config_id=#{sheet_config.id}, " \
+      "current_value=#{sync_params[:current_value]}"
+    )
+
+    render json: { success: true }, status: :ok
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.error("[Internal::SheetNumberingConfigs] Config not found for sync: #{e.message}")
+    render json: { error: 'Config not found' }, status: :not_found
+  rescue StandardError => e
+    Rails.logger.error("[Internal::SheetNumberingConfigs] Sync error: #{e.message}")
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
   private
 
   def authenticate_api_key!
@@ -66,5 +108,9 @@ class Api::V2::Internal::SheetNumberingConfigsController < ActionController::API
 
   def config_params
     params.permit(:account_id, :ai_agent_id, :numbering_key)
+  end
+
+  def sync_params
+    params.permit(:account_id, :ai_agent_id, :numbering_key, :current_value)
   end
 end

--- a/app/javascript/dashboard/api/sheetNumberingConfig.js
+++ b/app/javascript/dashboard/api/sheetNumberingConfig.js
@@ -17,8 +17,9 @@ const buildUrl = (aiAgentId) => {
 };
 
 export default {
-  getConfig(aiAgentId) {
-    return axios.get(`${buildUrl(aiAgentId)}/config`);
+  getConfig(aiAgentId, numberingKey) {
+    const params = numberingKey ? { numbering_key: numberingKey } : {};
+    return axios.get(`${buildUrl(aiAgentId)}/config`, { params });
   },
 
   updateConfig(aiAgentId, data) {

--- a/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
@@ -653,7 +653,11 @@
       "SAVING": "Saving....",
       "SUCCESS": "Success!",
       "SUCCESS_MESSAGE": "The numbering format data has been successfully saved.",
-      "CLOSE": "Close"
+      "CLOSE": "Close",
+      "WARN_MISSING_NUMBER": "The format must include [NUMBER] to ensure unique IDs.",
+      "WARN_MISSING_MONTH": "The format must include a month variable ([MONTH], [MONTH_ROMAN], [MONTH_SHORT], or [MONTH_LONG]) to avoid duplicate IDs.",
+      "WARN_MISSING_YEAR": "The format must include a year variable ([YEAR] or [YEAR_SHORT]) to avoid duplicate IDs.",
+      "WARN_CURRENT_VALUE_TOO_LOW": "The next number cannot be less than or equal to the current stored value ({storedValue})."
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
@@ -657,7 +657,9 @@
       "WARN_MISSING_NUMBER": "The format must include [NUMBER] to ensure unique IDs.",
       "WARN_MISSING_MONTH": "The format must include a month variable ([MONTH], [MONTH_ROMAN], [MONTH_SHORT], or [MONTH_LONG]) to avoid duplicate IDs.",
       "WARN_MISSING_YEAR": "The format must include a year variable ([YEAR] or [YEAR_SHORT]) to avoid duplicate IDs.",
-      "WARN_CURRENT_VALUE_TOO_LOW": "The next number cannot be less than or equal to the current stored value ({storedValue})."
+      "WARN_CURRENT_VALUE_TOO_LOW": "The next number must be greater than the last generated value ({storedValue}).",
+      "WARN_MIN_VALUE": "The next number must be at least 1.",
+      "SAVE_ERROR": "Failed to save numbering configuration."
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
@@ -663,7 +663,9 @@
       "WARN_MISSING_NUMBER": "Format harus menyertakan [NUMBER] untuk memastikan ID unik.",
       "WARN_MISSING_MONTH": "Format harus menyertakan variabel bulan ([MONTH], [MONTH_ROMAN], [MONTH_SHORT], atau [MONTH_LONG]) untuk menghindari ID duplikat.",
       "WARN_MISSING_YEAR": "Format harus menyertakan variabel tahun ([YEAR] atau [YEAR_SHORT]) untuk menghindari ID duplikat.",
-      "WARN_CURRENT_VALUE_TOO_LOW": "Nomor berikutnya tidak boleh kurang dari atau sama dengan nilai tersimpan saat ini ({storedValue})."
+      "WARN_CURRENT_VALUE_TOO_LOW": "Nomor berikutnya harus lebih besar dari nilai terakhir yang dibuat ({storedValue}).",
+      "WARN_MIN_VALUE": "Nomor berikutnya harus minimal 1.",
+      "SAVE_ERROR": "Gagal menyimpan konfigurasi penomoran."
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
@@ -659,7 +659,11 @@
       "SAVING": "Menyimpan....",
       "SUCCESS": "Sukses!",
       "SUCCESS_MESSAGE": "Data format penomoran berhasil disimpan.",
-      "CLOSE": "Tutup"
+      "CLOSE": "Tutup",
+      "WARN_MISSING_NUMBER": "Format harus menyertakan [NUMBER] untuk memastikan ID unik.",
+      "WARN_MISSING_MONTH": "Format harus menyertakan variabel bulan ([MONTH], [MONTH_ROMAN], [MONTH_SHORT], atau [MONTH_LONG]) untuk menghindari ID duplikat.",
+      "WARN_MISSING_YEAR": "Format harus menyertakan variabel tahun ([YEAR] atau [YEAR_SHORT]) untuk menghindari ID duplikat.",
+      "WARN_CURRENT_VALUE_TOO_LOW": "Nomor berikutnya tidak boleh kurang dari atau sama dengan nilai tersimpan saat ini ({storedValue})."
     }
   }
 }

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
@@ -1006,7 +1006,7 @@ onMounted(async () => {
 
         <!-- Custom Numbering Content -->
         <div v-show="activeIndex === 3" class="w-full">
-          <CustomNumberingTab :data="data" />
+          <CustomNumberingTab :data="data" numbering-key="booking" />
         </div>
       </div>
     </div>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/CSBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/CSBotView.vue
@@ -61,7 +61,7 @@
           <ProductCatalogTab :data="data" />
         </div>
         <div v-show="activeIndex === 6" class="w-full">
-          <CustomNumberingTab :data="data" />
+          <CustomNumberingTab :data="data" numbering-key="customer_service" />
         </div>
       </div>
 

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/LeadGenBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/LeadGenBotView.vue
@@ -472,7 +472,7 @@
 
         <!-- Tab 5: Custom Numbering Content -->
         <div v-show="activeIndex === 5" class="w-full">
-          <CustomNumberingTab :data="data" />
+          <CustomNumberingTab :data="data" numbering-key="lead_generation" />
         </div>
 
       </div>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/RestaurantBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/RestaurantBotView.vue
@@ -936,7 +936,7 @@ onMounted(async () => {
 
         <!-- Custom Numbering Content -->
         <div v-show="activeIndex === 3" class="w-full">
-          <CustomNumberingTab :data="data" />
+          <CustomNumberingTab :data="data" numbering-key="restaurant" />
         </div>
 
       </div>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
@@ -1586,7 +1586,7 @@
 
           <!-- Custom Numbering Content -->
           <div v-show="activeTabIndex === 7" class="w-full">
-            <CustomNumberingTab :data="data" />
+            <CustomNumberingTab :data="data" numbering-key="sales" />
           </div>
 
         </div>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CustomNumberingTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CustomNumberingTab.vue
@@ -227,6 +227,7 @@ export default {
       codeOption: '',
       showSuccessModal: false,
       loading: false,
+      storedCurrentValue: null,
     };
   },
   computed: {
@@ -266,11 +267,12 @@ export default {
       handler(newData) {
         // Load from flowData if number_format exists (backward compatibility)
         if (newData &&
-            newData.display_flow_data &&
-            newData.display_flow_data.agents_config &&
-            newData.display_flow_data.agents_config[0] &&
-            newData.display_flow_data.agents_config[0].configurations &&
-            newData.display_flow_data.agents_config[0].configurations.number_format
+          newData.display_flow_data &&
+          newData.display_flow_data.agents_config &&
+          newData.display_flow_data.agents_config[0] &&
+          newData.display_flow_data.agents_config[0].configurations &&
+          newData.display_flow_data.agents_config[0].configurations
+            .number_format
         ) {
           this.form = {
             ...this.form,
@@ -283,7 +285,54 @@ export default {
     }
   },
 
+  async created() {
+    try {
+      const { data } = await sheetNumberingConfigAPI.getConfig(this.data.id);
+      if (data && data.current_value != null) {
+        this.storedCurrentValue = data.current_value;
+      }
+    } catch (e) {
+      // New config, no stored value yet
+    }
+  },
+
   methods: {
+    validateBeforeSave() {
+      const format = this.form.format || '';
+      const warnings = [];
+
+      if (!format.includes('[NUMBER]')) {
+        warnings.push(this.$t('AGENT_MGMT.NUMBERING.WARN_MISSING_NUMBER'));
+      }
+
+      const monthVars = ['[MONTH]', '[MONTH_ROMAN]', '[MONTH_SHORT]', '[MONTH_LONG]'];
+      if (!monthVars.some(v => format.includes(v))) {
+        warnings.push(this.$t('AGENT_MGMT.NUMBERING.WARN_MISSING_MONTH'));
+      }
+
+      const yearVars = ['[YEAR]', '[YEAR_SHORT]'];
+      if (!yearVars.some(v => format.includes(v))) {
+        warnings.push(this.$t('AGENT_MGMT.NUMBERING.WARN_MISSING_YEAR'));
+      }
+
+      if (
+        this.storedCurrentValue != null &&
+        this.form.currentNumber <= this.storedCurrentValue
+      ) {
+        warnings.push(
+          this.$t('AGENT_MGMT.NUMBERING.WARN_CURRENT_VALUE_TOO_LOW', {
+            storedValue: this.storedCurrentValue,
+          })
+        );
+      }
+
+      if (warnings.length > 0) {
+        warnings.forEach(msg => useAlert(msg, { duration: 5000 }));
+        return false;
+      }
+      return true;
+    },
+
     addCode() {
       const token = this.codeOption;
       if (!token) return;
@@ -293,6 +342,7 @@ export default {
 
     async onSave() {
       if (this.loading) return;
+      if (!this.validateBeforeSave()) return;
 
       try {
         this.loading = true;
@@ -328,6 +378,9 @@ export default {
           reset_interval: this.form.resetEvery,
         };
         await sheetNumberingConfigAPI.updateConfig(this.data.id, configPayload);
+
+        // Update stored value after successful save
+        this.storedCurrentValue = this.form.currentNumber;
 
         // trigger parent refresh
         this.emitUpdate();

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CustomNumberingTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CustomNumberingTab.vue
@@ -213,6 +213,10 @@ export default {
       type: Object,
       required: true,
     },
+    numberingKey: {
+      type: String,
+      required: true,
+    },
   },
 
   data() {
@@ -228,6 +232,9 @@ export default {
       showSuccessModal: false,
       loading: false,
       storedCurrentValue: null,
+      lastSyncedValue: null,
+      lastSyncedAt: null,
+      storedResetInterval: null,
     };
   },
   computed: {
@@ -262,34 +269,22 @@ export default {
       return (this.form.prefix || '') + processedFormat;
     },
   },
-  watch: {
-    data: {
-      handler(newData) {
-        // Load from flowData if number_format exists (backward compatibility)
-        if (newData &&
-          newData.display_flow_data &&
-          newData.display_flow_data.agents_config &&
-          newData.display_flow_data.agents_config[0] &&
-          newData.display_flow_data.agents_config[0].configurations &&
-          newData.display_flow_data.agents_config[0].configurations
-            .number_format
-        ) {
-          this.form = {
-            ...this.form,
-            ...newData.display_flow_data.agents_config[0].configurations.number_format
-          };
-        }
-      },
-      immediate: true,
-      deep: true,
-    }
-  },
-
   async created() {
     try {
-      const { data } = await sheetNumberingConfigAPI.getConfig(this.data.id);
+      console.log('[CustomNumberingTab] created() called, fetching config for:', this.data.id, this.numberingKey);
+      const { data } = await sheetNumberingConfigAPI.getConfig(this.data.id, this.numberingKey);
+      console.log('[CustomNumberingTab] API response:', JSON.stringify(data));
       if (data && data.current_value != null) {
         this.storedCurrentValue = data.current_value;
+        this.lastSyncedValue = data.last_synced_value != null ? data.last_synced_value : null;
+        this.lastSyncedAt = data.last_synced_at || null;
+        this.storedResetInterval = data.reset_interval || 'never';
+        // Sync form fields from DB
+        this.form.currentNumber = data.current_value;
+        if (data.format_pattern) this.form.format = data.format_pattern;
+        if (data.number_padding) this.form.number_digits = data.number_padding;
+        if (data.reset_interval) this.form.resetEvery = data.reset_interval;
+        if (data.prefix != null) this.form.prefix = data.prefix;
       }
     } catch (e) {
       // New config, no stored value yet
@@ -315,13 +310,18 @@ export default {
         warnings.push(this.$t('AGENT_MGMT.NUMBERING.WARN_MISSING_YEAR'));
       }
 
+      if (!this.form.currentNumber || this.form.currentNumber < 1) {
+        warnings.push(this.$t('AGENT_MGMT.NUMBERING.WARN_MIN_VALUE'));
+      }
+
       if (
-        this.storedCurrentValue != null &&
-        this.form.currentNumber <= this.storedCurrentValue
+        this.lastSyncedValue != null &&
+        !this.isCurrentValueEditAllowed() &&
+        this.form.currentNumber <= this.lastSyncedValue
       ) {
         warnings.push(
           this.$t('AGENT_MGMT.NUMBERING.WARN_CURRENT_VALUE_TOO_LOW', {
-            storedValue: this.storedCurrentValue,
+            storedValue: this.lastSyncedValue,
           })
         );
       }
@@ -331,6 +331,26 @@ export default {
         return false;
       }
       return true;
+    },
+
+    isCurrentValueEditAllowed() {
+      // Never synced — no IDs ever generated
+      if (!this.lastSyncedAt) return true;
+
+      const syncDate = new Date(this.lastSyncedAt);
+      const now = new Date();
+
+      // For periodic resets, allow free editing if we're in a new period
+      if (this.storedResetInterval === 'month') {
+        return syncDate.getFullYear() < now.getFullYear() ||
+          syncDate.getMonth() < now.getMonth();
+      }
+      if (this.storedResetInterval === 'year') {
+        return syncDate.getFullYear() < now.getFullYear();
+      }
+
+      // 'never' — once synced, always restricted
+      return false;
     },
 
     addCode() {
@@ -354,9 +374,6 @@ export default {
           if (!flowData.agents_config[0].configurations) {
             flowData.agents_config[0].configurations = {};
           }
-          // Save to flow_data (backward compatibility)
-          flowData.agents_config[0].configurations.number_format = this.form;
-          displayFlowData.agents_config[0].configurations.number_format = this.form;
         } else {
           throw new Error("Format data tidak ditemukan.");
         }
@@ -366,18 +383,19 @@ export default {
           display_flow_data: displayFlowData,
         };
 
-        // Save to flow_data and display_flow_data
-        await aiAgents.updateAgent(this.data.id, payload);
-
-        // Also save to sheet_numbering_configs table
+        // Save to sheet_numbering_configs (source of truth)
         const configPayload = {
           prefix: this.form.prefix,
           format_pattern: this.form.format,
           current_value: this.form.currentNumber,
           number_padding: this.form.number_digits,
           reset_interval: this.form.resetEvery,
+          numbering_key: this.numberingKey,
         };
         await sheetNumberingConfigAPI.updateConfig(this.data.id, configPayload);
+
+        // Save flow_data (other config fields, excluding number_format)
+        await aiAgents.updateAgent(this.data.id, payload);
 
         // Update stored value after successful save
         this.storedCurrentValue = this.form.currentNumber;
@@ -389,6 +407,16 @@ export default {
 
       } catch (error) {
         console.error("Gagal menyimpan:", error);
+        const serverErrors = error?.response?.data?.errors;
+        if (serverErrors && Array.isArray(serverErrors)) {
+          serverErrors.forEach(msg => useAlert(msg, { duration: 5000 }));
+        } else {
+          useAlert(this.$t('AGENT_MGMT.NUMBERING.SAVE_ERROR'), { duration: 5000 });
+        }
+        // Revert form to last persisted values
+        if (this.storedCurrentValue != null) {
+          this.form.currentNumber = this.storedCurrentValue;
+        }
       } finally {
         this.loading = false;
       }

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CustomNumberingTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CustomNumberingTab.vue
@@ -21,20 +21,22 @@
           <div class="border-t border-gray-200 dark:border-gray-700 p-6 space-y-6">
             
             <div>
-              <label class="block text-sm font-medium mb-1 text-slate-900 dark:text-slate-25">
+              <label :class="labelClass">
                 {{ $t('AGENT_MGMT.NUMBERING.FORMAT') }} <span class="text-red-500">*</span>
               </label>
               <div class="flex flex-col sm:flex-row gap-2 mb-2">
                 <input 
                   v-model="form.format" 
                   type="text" 
-                  class="flex-1 p-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-800 focus:ring-2 focus:ring-green-500 focus:border-transparent text-slate-900 dark:text-slate-100 transition-all placeholder:text-gray-400"
+                  class="flex-1 focus:border-transparent placeholder:text-gray-400"
+                  :class="inputClass"
                   placeholder="[NUMBER]/[MONTH]/[YEAR]"
                 />
                 <select 
                   v-model="codeOption" 
                   @change="addCode"
-                  class="sm:w-64 p-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-800 focus:ring-2 focus:ring-green-500 text-slate-900 dark:text-slate-100 transition-all cursor-pointer"
+                  class="sm:w-64 cursor-pointer"
+                  :class="inputClass"
                 >
                   <option value="" disabled selected hidden>{{ $t('AGENT_MGMT.NUMBERING.ADD_CODE_TITLE') }}</option>
                   <option value="[NUMBER]">{{ $t('AGENT_MGMT.NUMBERING.OPTIONS.NUMBER') }}</option>
@@ -56,78 +58,59 @@
 
             <div class="grid grid-cols-1 md:grid-cols-3 gap-5">
               <div>
-                <label class="block text-sm font-medium mb-1 text-slate-900 dark:text-slate-25">
+                <label :class="labelClass">
                   {{ $t('AGENT_MGMT.NUMBERING.NUMBER') }} <span class="text-red-500">*</span>
                 </label>
                 <input 
                   v-model.number="form.currentNumber" 
                   type="number" 
                   min="1" 
-                  class="w-full p-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-800 focus:ring-2 focus:ring-green-500 text-slate-900 dark:text-slate-100 transition-all" 
+                  class="w-full"
+                  :class="inputClass"
                 />
               </div>
 
               <div>
-                <label class="block text-sm font-medium mb-1 text-slate-900 dark:text-slate-25">
+                <label :class="labelClass">
                   {{ $t('AGENT_MGMT.NUMBERING.DIGIT_NUMBER') }}
                 </label>
                 <input 
                   v-model.number="form.number_digits" 
                   type="number" 
                   min="3" 
-                  class="w-full p-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-800 focus:ring-2 focus:ring-green-500 text-slate-900 dark:text-slate-100 transition-all" 
+                  class="w-full"
+                  :class="inputClass"
                 />
                 <p class="text-[10px] text-gray-400 italic">Min: 3 (001)</p>
               </div>
 
               <div>
-                <label class="block text-sm font-medium mb-1 text-slate-900 dark:text-slate-25">
+                <label :class="labelClass">
                   {{ $t('AGENT_MGMT.NUMBERING.PREFIX') }}
                 </label>
                 <input 
                   v-model="form.prefix" 
                   type="text" 
                   :placeholder="$t('AGENT_MGMT.NUMBERING.PREFIX_EXP')"
-                  class="w-full p-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-800 focus:ring-2 focus:ring-green-500 text-slate-900 dark:text-slate-100 transition-all" 
+                  class="w-full"
+                  :class="inputClass"
                 />
               </div>
             </div>
 
             <div>
-              <label class="block text-sm font-medium mb-3 text-slate-900 dark:text-slate-25">
+              <label class="mb-3" :class="labelClass">
                 {{ $t('AGENT_MGMT.NUMBERING.RESET_TITLE') }}
               </label>
               <div class="flex flex-col gap-3">
-                <label class="flex items-center cursor-pointer group">
+                <label v-for="opt in resetOptions" :key="opt.value" class="flex items-center cursor-pointer group">
                   <div class="relative flex items-center">
-                    <input type="radio" value="never" v-model="form.resetEvery" class="peer sr-only" />
+                    <input type="radio" v-model="form.resetEvery" :value="opt.value" class="peer sr-only" />
                     <div class="w-5 h-5 border-2 border-gray-300 dark:border-gray-500 rounded-full peer-checked:border-green-500 peer-checked:bg-green-500 transition-all"></div>
                     <div class="absolute w-2 h-2 bg-white rounded-full left-1.5 top-1.5 opacity-0 peer-checked:opacity-100 transition-all"></div>
                   </div>
                   <span class="ml-3 text-sm text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
-                    {{ $t('AGENT_MGMT.NUMBERING.NEVER_RESET') }}
-                  </span>
-                </label>
-
-                <label class="flex items-center cursor-pointer group">
-                  <div class="relative flex items-center">
-                    <input type="radio" value="month" v-model="form.resetEvery" class="peer sr-only" />
-                    <div class="w-5 h-5 border-2 border-gray-300 dark:border-gray-500 rounded-full peer-checked:border-green-500 peer-checked:bg-green-500 transition-all"></div>
-                    <div class="absolute w-2 h-2 bg-white rounded-full left-1.5 top-1.5 opacity-0 peer-checked:opacity-100 transition-all"></div>
-                  </div>
-                  <span class="ml-3 text-sm text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
-                    {{ $t('AGENT_MGMT.NUMBERING.RESET_MONTHLY') }}
-                  </span>
-                </label>
-
-                <label class="flex items-center cursor-pointer group">
-                  <div class="relative flex items-center">
-                    <input type="radio" value="year" v-model="form.resetEvery" class="peer sr-only" />
-                    <div class="w-5 h-5 border-2 border-gray-300 dark:border-gray-500 rounded-full peer-checked:border-green-500 peer-checked:bg-green-500 transition-all"></div>
-                    <div class="absolute w-2 h-2 bg-white rounded-full left-1.5 top-1.5 opacity-0 peer-checked:opacity-100 transition-all"></div>
-                  </div>
-                  <span class="ml-3 text-sm text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
-                    {{ $t('AGENT_MGMT.NUMBERING.RESET_YEARLY') }}
+                    {{ opt.label }}
                   </span>
                 </label>
               </div>
@@ -231,13 +214,26 @@ export default {
       codeOption: '',
       showSuccessModal: false,
       loading: false,
-      storedCurrentValue: null,
-      lastSyncedValue: null,
+      savedCurrentNumber: null,
+      serverLastSyncedValue: null,
       lastSyncedAt: null,
       storedResetInterval: null,
     };
   },
   computed: {
+    inputClass() {
+      return 'p-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-800 focus:ring-2 focus:ring-green-500 text-slate-900 dark:text-slate-100 transition-all';
+    },
+    labelClass() {
+      return 'block text-sm font-medium mb-1 text-slate-900 dark:text-slate-25';
+    },
+    resetOptions() {
+      return [
+        { value: 'never', label: this.$t('AGENT_MGMT.NUMBERING.NEVER_RESET') },
+        { value: 'month', label: this.$t('AGENT_MGMT.NUMBERING.RESET_MONTHLY') },
+        { value: 'year', label: this.$t('AGENT_MGMT.NUMBERING.RESET_YEARLY') },
+      ];
+    },
     liveSampleOutput() {
       if (!this.form.format) return '...';
 
@@ -271,12 +267,10 @@ export default {
   },
   async created() {
     try {
-      console.log('[CustomNumberingTab] created() called, fetching config for:', this.data.id, this.numberingKey);
-      const { data } = await sheetNumberingConfigAPI.getConfig(this.data.id, this.numberingKey);
-      console.log('[CustomNumberingTab] API response:', JSON.stringify(data));
+          const { data } = await sheetNumberingConfigAPI.getConfig(newId, this.numberingKey);
       if (data && data.current_value != null) {
-        this.storedCurrentValue = data.current_value;
-        this.lastSyncedValue = data.last_synced_value != null ? data.last_synced_value : null;
+            this.savedCurrentNumber = data.current_value;
+            this.serverLastSyncedValue = data.last_synced_value != null ? data.last_synced_value : null;
         this.lastSyncedAt = data.last_synced_at || null;
         this.storedResetInterval = data.reset_interval || 'never';
         // Sync form fields from DB
@@ -315,13 +309,13 @@ export default {
       }
 
       if (
-        this.lastSyncedValue != null &&
+        this.serverLastSyncedValue != null &&
         !this.isCurrentValueEditAllowed() &&
-        this.form.currentNumber <= this.lastSyncedValue
+        this.form.currentNumber <= this.serverLastSyncedValue
       ) {
         warnings.push(
           this.$t('AGENT_MGMT.NUMBERING.WARN_CURRENT_VALUE_TOO_LOW', {
-            storedValue: this.lastSyncedValue,
+            storedValue: this.serverLastSyncedValue,
           })
         );
       }
@@ -366,24 +360,7 @@ export default {
 
       try {
         this.loading = true;
-        const flowData = JSON.parse(JSON.stringify(this.data.flow_data));
-        const displayFlowData = JSON.parse(JSON.stringify(this.data.display_flow_data));
 
-        // Ensure path exists
-        if (flowData.agents_config && flowData.agents_config[0]) {
-          if (!flowData.agents_config[0].configurations) {
-            flowData.agents_config[0].configurations = {};
-          }
-        } else {
-          throw new Error("Format data tidak ditemukan.");
-        }
-
-        const payload = {
-          flow_data: flowData,
-          display_flow_data: displayFlowData,
-        };
-
-        // Save to sheet_numbering_configs (source of truth)
         const configPayload = {
           prefix: this.form.prefix,
           format_pattern: this.form.format,
@@ -394,11 +371,7 @@ export default {
         };
         await sheetNumberingConfigAPI.updateConfig(this.data.id, configPayload);
 
-        // Save flow_data (other config fields, excluding number_format)
-        await aiAgents.updateAgent(this.data.id, payload);
-
-        // Update stored value after successful save
-        this.storedCurrentValue = this.form.currentNumber;
+        this.savedCurrentNumber = this.form.currentNumber;
 
         // trigger parent refresh
         this.emitUpdate();
@@ -414,8 +387,8 @@ export default {
           useAlert(this.$t('AGENT_MGMT.NUMBERING.SAVE_ERROR'), { duration: 5000 });
         }
         // Revert form to last persisted values
-        if (this.storedCurrentValue != null) {
-          this.form.currentNumber = this.storedCurrentValue;
+        if (this.savedCurrentNumber != null) {
+          this.form.currentNumber = this.savedCurrentNumber;
         }
       } finally {
         this.loading = false;

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CustomNumberingTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CustomNumberingTab.vue
@@ -25,9 +25,9 @@
                 {{ $t('AGENT_MGMT.NUMBERING.FORMAT') }} <span class="text-red-500">*</span>
               </label>
               <div class="flex flex-col sm:flex-row gap-2 mb-2">
-                <input 
-                  v-model="form.format" 
-                  type="text" 
+                <input
+                  v-model="form.format"
+                  type="text"
                   class="flex-1 focus:border-transparent placeholder:text-gray-400"
                   :class="inputClass"
                   placeholder="[NUMBER]/[MONTH]/[YEAR]"
@@ -74,10 +74,10 @@
                 <label :class="labelClass">
                   {{ $t('AGENT_MGMT.NUMBERING.DIGIT_NUMBER') }}
                 </label>
-                <input 
-                  v-model.number="form.number_digits" 
-                  type="number" 
-                  min="3" 
+                <input
+                  v-model.number="form.number_digits"
+                  type="number"
+                  min="3"
                   class="w-full"
                   :class="inputClass"
                 />
@@ -88,9 +88,9 @@
                 <label :class="labelClass">
                   {{ $t('AGENT_MGMT.NUMBERING.PREFIX') }}
                 </label>
-                <input 
-                  v-model="form.prefix" 
-                  type="text" 
+                <input
+                  v-model="form.prefix"
+                  type="text"
                   :placeholder="$t('AGENT_MGMT.NUMBERING.PREFIX_EXP')"
                   class="w-full"
                   :class="inputClass"
@@ -176,7 +176,6 @@
 
 <script>
 import { useAlert } from 'dashboard/composables';
-import aiAgents from '../../../../../api/aiAgents';
 import sheetNumberingConfigAPI from '../../../../../api/sheetNumberingConfig';
 import Button from 'dashboard/components-next/button/Button.vue';
 
@@ -265,24 +264,29 @@ export default {
       return (this.form.prefix || '') + processedFormat;
     },
   },
-  async created() {
-    try {
+  watch: {
+    'data.id': {
+      immediate: true,
+      async handler(newId) {
+        if (!newId) return;
+        try {
           const { data } = await sheetNumberingConfigAPI.getConfig(newId, this.numberingKey);
-      if (data && data.current_value != null) {
+          if (data && data.current_value != null) {
             this.savedCurrentNumber = data.current_value;
             this.serverLastSyncedValue = data.last_synced_value != null ? data.last_synced_value : null;
-        this.lastSyncedAt = data.last_synced_at || null;
-        this.storedResetInterval = data.reset_interval || 'never';
-        // Sync form fields from DB
-        this.form.currentNumber = data.current_value;
-        if (data.format_pattern) this.form.format = data.format_pattern;
-        if (data.number_padding) this.form.number_digits = data.number_padding;
-        if (data.reset_interval) this.form.resetEvery = data.reset_interval;
-        if (data.prefix != null) this.form.prefix = data.prefix;
-      }
-    } catch (e) {
-      // New config, no stored value yet
-    }
+            this.lastSyncedAt = data.last_synced_at || null;
+            this.storedResetInterval = data.reset_interval || 'never';
+            this.form.currentNumber = data.current_value;
+            if (data.format_pattern) this.form.format = data.format_pattern;
+            if (data.number_padding) this.form.number_digits = data.number_padding;
+            if (data.reset_interval) this.form.resetEvery = data.reset_interval;
+            if (data.prefix != null) this.form.prefix = data.prefix;
+          }
+        } catch (e) {
+          // New config, no stored value yet
+        }
+      },
+    },
   },
 
   methods: {

--- a/app/jobs/sync_numbering_counter_job.rb
+++ b/app/jobs/sync_numbering_counter_job.rb
@@ -1,0 +1,54 @@
+class SyncNumberingCounterJob < ApplicationJob
+  queue_as :default
+
+  # Called when a user updates current_value in the Chatwoot UI to push
+  # the new value to Jangkau's numbering_counters table and invalidate
+  # its Redis cache.
+  #
+  # @param account_id [Integer] The account ID
+  # @param ai_agent_id [Integer] The AI agent ID
+  # @param numbering_key [String] The numbering key (e.g., "booking")
+  # @param current_value [Integer] The desired next value to generate
+  def perform(account_id, ai_agent_id, numbering_key, current_value)
+    Rails.logger.info(
+      "[SyncNumberingCounterJob] Syncing counter for " \
+      "account=#{account_id}, ai_agent=#{ai_agent_id}, " \
+      "key=#{numbering_key}, current_value=#{current_value}"
+    )
+
+    base_url = ENV.fetch('JANGKAU_AGENT_API_URL', nil)
+    api_key = ENV.fetch('JANGKAU_AGENT_API_KEY', nil)
+
+    unless base_url.present?
+      Rails.logger.warn('[SyncNumberingCounterJob] JANGKAU_AGENT_API_URL not configured, skipping')
+      return
+    end
+
+    response = HTTParty.put(
+      "#{base_url}v2/numbering/counters",
+      body: {
+        account_id: account_id,
+        ai_agent_id: ai_agent_id,
+        numbering_key: numbering_key,
+        current_value: current_value
+      }.to_json,
+      headers: {
+        'Content-Type' => 'application/json',
+        'X-API-Key' => api_key
+      },
+      timeout: 10
+    )
+
+    if response.success?
+      Rails.logger.info(
+        "[SyncNumberingCounterJob] Successfully synced counter: #{response.parsed_response}"
+      )
+    else
+      Rails.logger.error(
+        "[SyncNumberingCounterJob] Failed to sync counter: #{response.code} - #{response.body}"
+      )
+    end
+  rescue StandardError => e
+    Rails.logger.error("[SyncNumberingCounterJob] Error: #{e.message}")
+  end
+end

--- a/app/models/ai_agent.rb
+++ b/app/models/ai_agent.rb
@@ -166,17 +166,24 @@ class AiAgent < ApplicationRecord
   end
 
   def create_default_numbering_config
-    sheet_numbering_configs.create!(
-      account: account,
-      numbering_key: 'default',
-      prefix: nil,
-      format_pattern: '[NUMBER]/[MONTH]/[YEAR]',
-      current_value: 1,
-      number_padding: 3,
-      reset_interval: 'never'
-    )
+    enabled_agents_list.each do |agent_key|
+      sheet_numbering_configs.create!(
+        account: account,
+        numbering_key: agent_key,
+        prefix: nil,
+        format_pattern: '[NUMBER]/[MONTH]/[YEAR]',
+        current_value: 1,
+        number_padding: 3,
+        reset_interval: 'never'
+      )
+    end
   rescue ActiveRecord::RecordInvalid => e
-    Rails.logger.error("[AiAgent] Failed to create default numbering config: #{e.message}")
+    Rails.logger.error("[AiAgent] Failed to create numbering config: #{e.message}")
+  end
+
+  def enabled_agents_list
+    agents = flow_data&.dig('enabled_agents') || []
+    agents.presence || ['default']
   end
 
   def cleanup_numbering_counters

--- a/app/models/sheet_numbering_config.rb
+++ b/app/models/sheet_numbering_config.rb
@@ -2,17 +2,19 @@
 #
 # Table name: sheet_numbering_configs
 #
-#  id             :bigint           not null, primary key
-#  current_value  :integer          default(1), not null
-#  format_pattern :string           default("[NUMBER]/[MONTH]/[YEAR]"), not null
-#  number_padding :integer          default(3), not null
-#  numbering_key  :string           default("default"), not null
-#  prefix         :string
-#  reset_interval :string           default("never"), not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  account_id     :bigint           not null
-#  ai_agent_id    :bigint           not null
+#  id                :bigint           not null, primary key
+#  current_value     :integer          default(1), not null
+#  format_pattern    :string           default("[NUMBER]/[MONTH]/[YEAR]"), not null
+#  last_synced_at    :datetime
+#  last_synced_value :integer
+#  number_padding    :integer          default(3), not null
+#  numbering_key     :string           default("default"), not null
+#  prefix            :string
+#  reset_interval    :string           default("never"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  account_id        :bigint           not null
+#  ai_agent_id       :bigint           not null
 #
 # Indexes
 #
@@ -64,8 +66,29 @@ class SheetNumberingConfig < ApplicationRecord
   def current_value_must_not_decrease
     return unless current_value_changed?
 
-    if current_value <= current_value_was.to_i
-      errors.add(:current_value, "must be greater than current stored value (#{current_value_was})")
+    # No IDs ever generated — free to edit
+    return if last_synced_value.nil?
+
+    # New reset period — counter has reset, free to edit
+    return if new_reset_period?
+
+    # Must be greater than the highest actually-generated ID
+    min_allowed = last_synced_value + 1
+    return if current_value >= min_allowed
+
+    errors.add(:current_value, "must be greater than the last generated value (#{last_synced_value})")
+  end
+
+  def new_reset_period?
+    return true if last_synced_at.nil?
+
+    case reset_interval
+    when 'month'
+      last_synced_at.beginning_of_month < Time.current.beginning_of_month
+    when 'year'
+      last_synced_at.beginning_of_year < Time.current.beginning_of_year
+    else
+      false
     end
   end
 end

--- a/app/models/sheet_numbering_config.rb
+++ b/app/models/sheet_numbering_config.rb
@@ -31,6 +31,8 @@ class SheetNumberingConfig < ApplicationRecord
   belongs_to :ai_agent
 
   VALID_RESET_INTERVALS = %w[never month year].freeze
+  MONTH_VARIABLES = %w[[MONTH] [MONTH_ROMAN] [MONTH_SHORT] [MONTH_LONG]].freeze
+  YEAR_VARIABLES = %w[[YEAR] [YEAR_SHORT]].freeze
 
   # Unique constraint now includes numbering_key to support multiple configs per ai_agent
   validates :ai_agent_id, uniqueness: { scope: [:account_id, :numbering_key] }
@@ -39,4 +41,31 @@ class SheetNumberingConfig < ApplicationRecord
   validates :number_padding, numericality: { greater_than_or_equal_to: 1 }
   validates :reset_interval, inclusion: { in: VALID_RESET_INTERVALS }
   validates :numbering_key, presence: true
+
+  validate :format_pattern_must_contain_required_variables
+  validate :current_value_must_not_decrease, on: :update
+
+  private
+
+  def format_pattern_must_contain_required_variables
+    return if format_pattern.blank?
+
+    unless format_pattern.include?('[NUMBER]')
+      errors.add(:format_pattern, 'must include [NUMBER]')
+    end
+    unless MONTH_VARIABLES.any? { |v| format_pattern.include?(v) }
+      errors.add(:format_pattern, 'must include a month variable ([MONTH], [MONTH_ROMAN], [MONTH_SHORT], or [MONTH_LONG])')
+    end
+    unless YEAR_VARIABLES.any? { |v| format_pattern.include?(v) }
+      errors.add(:format_pattern, 'must include a year variable ([YEAR] or [YEAR_SHORT])')
+    end
+  end
+
+  def current_value_must_not_decrease
+    return unless current_value_changed?
+
+    if current_value <= current_value_was.to_i
+      errors.add(:current_value, "must be greater than current stored value (#{current_value_was})")
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -556,7 +556,7 @@ Rails.application.routes.draw do
 
         resources :sheet_numbering_configs, only: [] do
           collection do
-            get :config
+            get :config, action: :show_config
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -559,6 +559,7 @@ Rails.application.routes.draw do
         resources :sheet_numbering_configs, only: [] do
           collection do
             get :config, action: :show_config
+            put :sync_counter, action: :sync_counter
           end
         end
       end

--- a/db/migrate/20260128102904_add_last_synced_at_to_sheet_numbering_configs.rb
+++ b/db/migrate/20260128102904_add_last_synced_at_to_sheet_numbering_configs.rb
@@ -1,0 +1,12 @@
+class AddLastSyncedAtToSheetNumberingConfigs < ActiveRecord::Migration[7.0]
+  def up
+    add_column :sheet_numbering_configs, :last_synced_at, :datetime, null: true
+
+    # Backfill: configs with current_value > 1 have likely been synced by jangkau
+    SheetNumberingConfig.where('current_value > 1').update_all('last_synced_at = updated_at')
+  end
+
+  def down
+    remove_column :sheet_numbering_configs, :last_synced_at
+  end
+end

--- a/db/migrate/20260129040000_add_last_synced_value_to_sheet_numbering_configs.rb
+++ b/db/migrate/20260129040000_add_last_synced_value_to_sheet_numbering_configs.rb
@@ -1,0 +1,12 @@
+class AddLastSyncedValueToSheetNumberingConfigs < ActiveRecord::Migration[7.0]
+  def up
+    add_column :sheet_numbering_configs, :last_synced_value, :integer, null: true
+
+    # Backfill: configs that have been synced (last_synced_at present) should use current_value
+    SheetNumberingConfig.where.not(last_synced_at: nil).update_all('last_synced_value = current_value')
+  end
+
+  def down
+    remove_column :sheet_numbering_configs, :last_synced_value
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_01_27_030656) do
+ActiveRecord::Schema[7.0].define(version: 2026_01_29_040000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -59,6 +59,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_27_030656) do
     t.integer "status", default: 0
     t.bigint "active_subscription_id"
     t.string "subscription_status", default: "free_trial"
+    t.jsonb "internal_attributes", default: {}, null: false
     t.index ["active_subscription_id"], name: "index_accounts_on_active_subscription_id"
     t.index ["status"], name: "index_accounts_on_status"
   end
@@ -223,9 +224,13 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_27_030656) do
     t.string "slug", null: false
     t.integer "position"
     t.string "locale", default: "en", null: false
+    t.index ["account_id"], name: "index_articles_on_account_id"
     t.index ["associated_article_id"], name: "index_articles_on_associated_article_id"
     t.index ["author_id"], name: "index_articles_on_author_id"
+    t.index ["portal_id"], name: "index_articles_on_portal_id"
     t.index ["slug"], name: "index_articles_on_slug", unique: true
+    t.index ["status"], name: "index_articles_on_status"
+    t.index ["views"], name: "index_articles_on_views"
   end
 
   create_table "attachments", id: :serial, force: :cascade do |t|
@@ -239,6 +244,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_27_030656) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "fallback_title"
     t.string "extension"
+    t.jsonb "meta", default: {}
     t.index ["account_id"], name: "index_attachments_on_account_id"
     t.index ["message_id"], name: "index_attachments_on_message_id"
   end
@@ -517,6 +523,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_27_030656) do
     t.jsonb "pre_chat_form_options", default: {}
     t.boolean "hmac_mandatory", default: false
     t.boolean "continuity_via_email", default: true, null: false
+    t.string "widget_heading"
     t.index ["hmac_token"], name: "index_channel_web_widgets_on_hmac_token", unique: true
     t.index ["website_token"], name: "index_channel_web_widgets_on_website_token", unique: true
   end
@@ -1062,15 +1069,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_27_030656) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "portal_members", force: :cascade do |t|
-    t.bigint "portal_id"
-    t.bigint "user_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.index ["portal_id", "user_id"], name: "index_portal_members_on_portal_id_and_user_id", unique: true
-    t.index ["user_id", "portal_id"], name: "index_portal_members_on_user_id_and_portal_id", unique: true
-  end
-
   create_table "portals", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "name", null: false
@@ -1166,7 +1164,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_27_030656) do
     t.datetime "updated_at", null: false
     t.string "service_id"
     t.string "message"
-    t.index ["account_id", "inbox_id", "ai_agent_id", "conversation_id", "service_id"], name: "reminders_unique_idx", unique: true
     t.index ["account_id", "scheduled_at"], name: "index_reminders_on_account_id_and_scheduled_at"
     t.index ["account_id"], name: "index_reminders_on_account_id"
     t.index ["ai_agent_id"], name: "index_reminders_on_ai_agent_id"
@@ -1207,6 +1204,8 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_27_030656) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "numbering_key", default: "default", null: false
+    t.datetime "last_synced_at"
+    t.integer "last_synced_value"
     t.index ["account_id", "ai_agent_id", "numbering_key"], name: "idx_sheet_numbering_configs_unique_key", unique: true
     t.index ["account_id"], name: "index_sheet_numbering_configs_on_account_id"
     t.index ["ai_agent_id"], name: "index_sheet_numbering_configs_on_ai_agent_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_01_29_040000) do
+ActiveRecord::Schema[7.0].define(version: 2026_01_27_030656) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -59,7 +59,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_29_040000) do
     t.integer "status", default: 0
     t.bigint "active_subscription_id"
     t.string "subscription_status", default: "free_trial"
-    t.jsonb "internal_attributes", default: {}, null: false
     t.index ["active_subscription_id"], name: "index_accounts_on_active_subscription_id"
     t.index ["status"], name: "index_accounts_on_status"
   end
@@ -224,13 +223,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_29_040000) do
     t.string "slug", null: false
     t.integer "position"
     t.string "locale", default: "en", null: false
-    t.index ["account_id"], name: "index_articles_on_account_id"
     t.index ["associated_article_id"], name: "index_articles_on_associated_article_id"
     t.index ["author_id"], name: "index_articles_on_author_id"
-    t.index ["portal_id"], name: "index_articles_on_portal_id"
     t.index ["slug"], name: "index_articles_on_slug", unique: true
-    t.index ["status"], name: "index_articles_on_status"
-    t.index ["views"], name: "index_articles_on_views"
   end
 
   create_table "attachments", id: :serial, force: :cascade do |t|
@@ -244,7 +239,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_29_040000) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "fallback_title"
     t.string "extension"
-    t.jsonb "meta", default: {}
     t.index ["account_id"], name: "index_attachments_on_account_id"
     t.index ["message_id"], name: "index_attachments_on_message_id"
   end
@@ -523,7 +517,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_29_040000) do
     t.jsonb "pre_chat_form_options", default: {}
     t.boolean "hmac_mandatory", default: false
     t.boolean "continuity_via_email", default: true, null: false
-    t.string "widget_heading"
     t.index ["hmac_token"], name: "index_channel_web_widgets_on_hmac_token", unique: true
     t.index ["website_token"], name: "index_channel_web_widgets_on_website_token", unique: true
   end
@@ -1069,6 +1062,15 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_29_040000) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  create_table "portal_members", force: :cascade do |t|
+    t.bigint "portal_id"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["portal_id", "user_id"], name: "index_portal_members_on_portal_id_and_user_id", unique: true
+    t.index ["user_id", "portal_id"], name: "index_portal_members_on_user_id_and_portal_id", unique: true
+  end
+
   create_table "portals", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "name", null: false
@@ -1164,6 +1166,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_29_040000) do
     t.datetime "updated_at", null: false
     t.string "service_id"
     t.string "message"
+    t.index ["account_id", "inbox_id", "ai_agent_id", "conversation_id", "service_id"], name: "reminders_unique_idx", unique: true
     t.index ["account_id", "scheduled_at"], name: "index_reminders_on_account_id_and_scheduled_at"
     t.index ["account_id"], name: "index_reminders_on_account_id"
     t.index ["ai_agent_id"], name: "index_reminders_on_ai_agent_id"
@@ -1204,8 +1207,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_29_040000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "numbering_key", default: "default", null: false
-    t.datetime "last_synced_at"
-    t.integer "last_synced_value"
     t.index ["account_id", "ai_agent_id", "numbering_key"], name: "idx_sheet_numbering_configs_unique_key", unique: true
     t.index ["account_id"], name: "index_sheet_numbering_configs_on_account_id"
     t.index ["ai_agent_id"], name: "index_sheet_numbering_configs_on_ai_agent_id"


### PR DESCRIPTION
## Description

Implements bidirectional counter synchronization between Chatwoot and Jangkau for sheet numbering configurations, and adds support for per-bot-type numbering keys.

### Problems solved:
- **Counter drift**: When a user manually updates current_value in the Chatwoot UI, Jangkau was not notified, causing the two systems to fall out of sync and risk generating duplicate IDs.
- **No per-bot-type numbering**: All bot types shared a single numbering sequence. Each bot type (booking, sales, lead generation, etc.) now gets its own independent counter via a numbering_key parameter.
- **Weak validation**: Format patterns could be saved without required variables ([NUMBER], month, year), and users could decrease counter values below already-generated IDs, risking duplicates.
- **ActiveSupport conflict**: The internal controller's config action name clashed with ActiveSupport::Configurable.

### Key changes:

#### Backend
- **New sync_counter internal endpoint** (PUT /api/v2/internal/sheet_numbering_configs/sync_counter) — called by Jangkau after each ID generation to push current_value, last_synced_at, and last_synced_value back to Chatwoot.
- **New SyncNumberingCounterJob** — enqueued when a user updates current_value via the UI, pushing the new value to Jangkau's counters API.
- **Two migrations** adding last_synced_at (datetime) and last_synced_value (integer) columns to sheet_numbering_configs, with backfill logic for existing rows.
- **Model validations** on SheetNumberingConfig: format_pattern must contain [NUMBER], a month variable, and a year variable; current_value cannot decrease below last_synced_value unless a new reset period has started.
- **AiAgent#create_default_numbering_config** now creates one config per enabled agent type instead of a single default.
- **Auth change**: Internal API now uses JANGKAU_AGENT_API_KEY (via X-API-Key header) instead of the previous JANGKAU_INTERNAL_API_KEY.
- **Renamed** internal config action to show_config to avoid the ActiveSupport naming conflict.

#### Frontend
- **CustomNumberingTab refactored**: removed dead flowData persistence logic; now loads config from the API after data.id is available; validates format patterns and counter values client-side before save; shows server-side validation errors.
- **numbering-key prop** added to CustomNumberingTab and passed from each bot view (booking, customer_service, lead_generation, restaurant, sales).
- **API client** (sheetNumberingConfig.js) updated to pass optional numbering_key query parameter.
- **New i18n keys** (EN + ID) for validation warnings (missing [NUMBER], missing month/year, counter too low).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Manual counter sync (UI → Jangkau): Updated current_value in the Chatwoot numbering config UI and verified SyncNumberingCounterJob enqueued and Jangkau's counter endpoint received the correct value.
2. Inbound sync (Jangkau → Chatwoot): Called PUT /api/v2/internal/sheet_numbering_configs/sync_counter with a valid API key and confirmed current_value, last_synced_at, and last_synced_value updated in the database.
3. Validation — format pattern: Attempted to save a format pattern missing [NUMBER], month, or year variables and verified client-side and server-side errors are shown.
4. Validation — counter decrease: Set current_value below last_synced_value and confirmed the save is rejected (unless a new reset period applies).
5. Per-bot numbering keys: Created an AI agent with multiple enabled bot types, confirmed each bot view loads and saves its own independent numbering config via the correct numbering_key.
6. Auth: Verified requests with an invalid or missing X-API-Key header return 401 on the internal endpoints.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
