### PR TITLE
fix: add team internal notification setting to Sales Bot config

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
@@ -655,6 +655,11 @@
         "ENABLED_DESC_DETAIL": "Customers can add multiple products to their cart and checkout all items together",
         "DISABLED_STATUS": "Shopping cart is disabled",
         "DISABLED_DESC_DETAIL": "Customers will purchase products individually without cart functionality"
+      },
+      "NOTIFICATION": {
+        "TITLE": "Internal Team Notification Settings",
+        "DESC": "Configure automatic internal notifications when a new order is placed.",
+        "TEMPLATE_HELP": "This message will be sent automatically to your internal team to notify them of new orders."
       }
     },
     "EOBOT": {

--- a/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
@@ -474,6 +474,11 @@
         "ENABLED_DESC_DETAIL": "Pelanggan dapat menambahkan beberapa produk ke keranjang mereka dan checkout semua item bersamaan",
         "DISABLED_STATUS": "Keranjang belanja dinonaktifkan",
         "DISABLED_DESC_DETAIL": "Pelanggan akan membeli produk secara individual tanpa fungsi keranjang"
+      },
+      "NOTIFICATION": {
+        "TITLE": "Pengaturan Notifikasi Tim Internal",
+        "DESC": "Atur notifikasi internal otomatis saat pesanan baru dibuat.",
+        "TEMPLATE_HELP": "Pesan ini akan dikirim otomatis ke tim internal Anda untuk memberitahukan pesanan yang masuk."
       }
     },
     "EOBOT": {

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
@@ -226,6 +226,16 @@
                     </a>
                   </div>
                 </div>
+
+                <!-- Notification Settings -->
+                <NotificationSettings
+                  :ai-agent-id="data.id"
+                  :categories="[]"
+                  :show-filters="false"
+                  title-key="AGENT_MGMT.SALESBOT.NOTIFICATION.TITLE"
+                  desc-key="AGENT_MGMT.SALESBOT.NOTIFICATION.DESC"
+                  :variable-config="salesVariableConfig"
+                />
               </div>
             </div>
           </div>
@@ -1667,6 +1677,7 @@ import shippingStoresAPI from '../../../../api/shippingStores';
 import { useAlert } from 'dashboard/composables';
 import CustomNumberingTab from './cs-bot-tabs/CustomNumberingTab.vue';
 import ShippingConfig from './sales-bot-tabs/ShippingConfig.vue';
+import NotificationSettings from './notification-settings/NotificationSettings.vue';
 
 const { t } = useI18n();
 const store = useStore();
@@ -1823,6 +1834,26 @@ const salesAuthError = computed(() => {
 });
 
 const notification = ref(null);
+
+const salesVariableConfig = computed(() => ({
+  helpKey: 'AGENT_MGMT.SALESBOT.NOTIFICATION.TEMPLATE_HELP',
+  variables: [
+    {
+      labelKey: 'AGENT_MGMT.NOTIFICATION.VAR_CONTENT_SUMMARY',
+      value: '{{content_summary}}',
+      example: `ID Pesanan: SO-001/01/2026
+Nama Pelanggan: Budi Santoso
+No. Telp: 62812345678901
+Produk: Paket Premium A
+Jumlah: 2
+Total: Rp 500,000
+Metode Pembayaran: Bank Transfer
+Status: Menunggu Pembayaran
+Catatan: Kirim sebelum jam 5 sore`,
+    },
+  ],
+}));
+
 const productColumns = ref('sku,name,unit_price,quantity,deskripsi');
 const syncingColumns = ref(false);
 const authError = computed(() => props.googleSheetsAuth.error);


### PR DESCRIPTION
# Pull Request Template

## Description

Adds team internal notification setting to the Sales Bot configuration and place below the sheet output section.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified in the dashboard UI that the Sales Bot displays and saves the team internal notification setting correctly.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules