### PR TITLE
feat: improve notification settings inbox ux

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
@@ -239,8 +239,8 @@
       }
     },
     "NOTIFICATION": {
-      "SENDER_INBOX_LABEL": "Sender Inbox",
-      "SENDER_INBOX_PLACEHOLDER": "— Select sender inbox —",
+      "SENDER_INBOX_LABEL": "Sender Platform",
+      "SENDER_INBOX_PLACEHOLDER": "— Select sender platform —",
       "ADD_BUTTON": "+ Add Notification",
       "EMPTY_STATE": "No notifications have been added yet.",
       "FORM_TITLE_ADD": "Add Notification",
@@ -280,8 +280,9 @@
       "CARD_MESSAGE_LABEL": "Message",
       "CARD_EDIT": "Edit",
       "CARD_DELETE": "Delete",
-      "NO_INBOX_AVAILABLE": "No connected WhatsApp Go inbox available. Please create a WhatsApp Go inbox or ensure an existing one is properly connected.",
-      "NO_GROUPS": "No groups found. Ensure the sender inbox is connected.",
+      "NO_INBOX_AVAILABLE": "No connected WhatsApp Go platform available. Please create a WhatsApp Go platform or ensure an existing one is properly connected.",
+      "INBOX_DISCONNECTED_WARNING": "This platform is disconnected. Please reconnect it or select a different connected platform.",
+      "NO_GROUPS": "No groups found. Ensure the sender platform is connected.",
       "LOADING_GROUPS": "Loading groups...",
       "GROUP_SEARCH_PLACEHOLDER": "Type group name to search",
       "NO_GROUPS_FOUND": "No groups found",

--- a/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
@@ -239,8 +239,8 @@
       }
     },
     "NOTIFICATION": {
-      "SENDER_INBOX_LABEL": "Inbox Pengirim",
-      "SENDER_INBOX_PLACEHOLDER": "— Pilih inbox pengirim —",
+      "SENDER_INBOX_LABEL": "Platform Pengirim",
+      "SENDER_INBOX_PLACEHOLDER": "— Pilih platform pengirim —",
       "ADD_BUTTON": "+ Tambah Notifikasi",
       "EMPTY_STATE": "Belum ada notifikasi yang ditambahkan.",
       "FORM_TITLE_ADD": "Tambah Notifikasi",
@@ -280,8 +280,9 @@
       "CARD_MESSAGE_LABEL": "Pesan",
       "CARD_EDIT": "Edit",
       "CARD_DELETE": "Hapus",
-      "NO_INBOX_AVAILABLE": "Tidak ada inbox WhatsApp Go yang terhubung. Silakan buat inbox WhatsApp Go baru atau pastikan inbox yang ada sudah terhubung dengan benar.",
-      "NO_GROUPS": "Tidak ada grup yang ditemukan. Pastikan inbox pengirim sudah terhubung.",
+      "NO_INBOX_AVAILABLE": "Tidak ada platform WhatsApp Go yang terhubung. Silakan buat platform WhatsApp Go baru atau pastikan platform yang ada sudah terhubung dengan benar.",
+      "INBOX_DISCONNECTED_WARNING": "Platform ini terputus. Silakan hubungkan kembali atau pilih platform lain yang sudah terhubung.",
+      "NO_GROUPS": "Tidak ada grup yang ditemukan. Pastikan platform pengirim sudah terhubung.",
       "LOADING_GROUPS": "Memuat grup...",
       "GROUP_SEARCH_PLACEHOLDER": "Ketik nama grup untuk mencari",
       "NO_GROUPS_FOUND": "Tidak ada grup ditemukan",

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/notification-settings/NotificationCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/notification-settings/NotificationCard.vue
@@ -70,6 +70,12 @@ const formattedMessage = computed(() => {
   );
 });
 
+// Expand/collapse state for the entire card body
+const isCardExpanded = ref(true);
+const toggleCardExpand = () => {
+  isCardExpanded.value = !isCardExpanded.value;
+};
+
 // Expand/collapse state for message preview
 const isExpanded = ref(false);
 const messageRef = ref(null);
@@ -109,7 +115,7 @@ const interestBadgeColor =
     class="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-transparent"
   >
     <!-- Header: Category + Interest Badge + Actions -->
-    <div class="flex items-start justify-between gap-3 mb-4">
+    <div class="flex items-start justify-between gap-3" :class="{ 'mb-4': isCardExpanded }">
       <!-- Title Group -->
       <div class="flex items-center gap-3 flex-1 min-w-0">
         <div class="flex items-center gap-2 flex-1 min-w-0">
@@ -174,12 +180,23 @@ const interestBadgeColor =
         >
           {{ $t('AGENT_MGMT.NOTIFICATION.CARD_DELETE') }}
         </Button>
+        <button
+          type="button"
+          class="p-1.5 rounded-md text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors duration-200"
+          :aria-expanded="isCardExpanded"
+          @click="toggleCardExpand"
+        >
+          <span
+            class="i-lucide-chevron-down size-4 block transition-transform duration-200"
+            :class="{ 'rotate-180': !isCardExpanded }"
+          />
+        </button>
       </div>
     </div>
 
     <!-- Divider -->
+    <div v-show="isCardExpanded">
     <div class="border-t border-gray-200 dark:border-gray-700 mb-4" />
-
     <!-- Sender & Receiver Section (Two Columns) -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
       <!-- Sender -->
@@ -277,6 +294,7 @@ const interestBadgeColor =
           }}
         </button>
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/notification-settings/NotificationCard.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/notification-settings/NotificationCard.vue
@@ -14,6 +14,10 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+  allWhatsappUnofficialInboxes: {
+    type: Array,
+    default: () => [],
+  },
   whatsappGroups: {
     type: Array,
     default: () => [],
@@ -22,11 +26,16 @@ const props = defineProps({
 
 const emit = defineEmits(['edit', 'delete']);
 
-// Sender inbox info
+// Sender inbox info — look up from all inboxes (including disconnected)
 const senderInbox = computed(() => {
-  return props.whatsappUnofficialInboxes.find(
+  return props.allWhatsappUnofficialInboxes.find(
     i => i.id === props.rule.inbox_id
   );
+});
+
+const isInboxDisconnected = computed(() => {
+  if (!senderInbox.value) return false;
+  return senderInbox.value.whatsapp_status !== 'connected';
 });
 
 const senderInboxName = computed(() => {
@@ -174,12 +183,14 @@ const interestBadgeColor =
     <!-- Sender & Receiver Section (Two Columns) -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
       <!-- Sender -->
-      <div>
+      <div class="flex flex-col">
         <div class="text-xs font-medium text-slate-500 dark:text-slate-400 mb-2 flex items-center gap-1.5">
           <span class="i-lucide-send text-slate-400 dark:text-slate-500 size-3.5" />
           {{ $t('AGENT_MGMT.NOTIFICATION.CARD_SENT_FROM') }}
         </div>
-        <div class="p-3 rounded-lg bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700">
+        <div
+          class="flex-1 p-3 rounded-lg bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700"
+        >
           <div class="flex items-center gap-2 mb-1">
             <span class="i-lucide-smartphone text-slate-500 dark:text-slate-400 size-4" />
             <span class="text-sm font-medium text-slate-800 dark:text-slate-200 truncate" :title="senderInboxName">
@@ -195,16 +206,25 @@ const interestBadgeColor =
           >
             {{ senderPhoneNumber }}
           </div>
+          <div
+            v-if="isInboxDisconnected"
+            class="mt-2 flex items-start gap-1.5 text-xs text-slate-500 dark:text-slate-400"
+          >
+            <span class="i-lucide-triangle-alert size-3.5 flex-shrink-0 mt-0.5" />
+            <span>{{ $t('AGENT_MGMT.NOTIFICATION.INBOX_DISCONNECTED_WARNING') }}</span>
+          </div>
         </div>
       </div>
 
       <!-- Receiver -->
-      <div>
+      <div class="flex flex-col">
         <div class="text-xs font-medium text-slate-500 dark:text-slate-400 mb-2 flex items-center gap-1.5">
           <span class="i-lucide-inbox text-slate-400 dark:text-slate-500 size-3.5" />
           {{ $t('AGENT_MGMT.NOTIFICATION.CARD_SEND_TO') }}
         </div>
-        <div class="p-3 rounded-lg bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700">
+        <div
+          class="flex-1 p-3 rounded-lg bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700"
+        >
           <div class="flex items-center gap-2 mb-1">
             <span
               :class="rule.message_type === 'group' ? 'i-lucide-users' : 'i-lucide-user'"

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/notification-settings/NotificationFormModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/notification-settings/NotificationFormModal.vue
@@ -18,6 +18,10 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+  allWhatsappUnofficialInboxes: {
+    type: Array,
+    default: () => [],
+  },
   categories: {
     type: Array,
     default: () => [],
@@ -147,9 +151,19 @@ const hasContentSummary = computed(() => {
   return messageTemplate.value.includes('{{content_summary}}');
 });
 
+const editingDisconnectedInbox = computed(() => {
+  if (!props.rule || !senderInboxId.value) return null;
+  const connectedIds = props.whatsappUnofficialInboxes.map(i => i.id);
+  if (connectedIds.includes(senderInboxId.value)) return null;
+  return props.allWhatsappUnofficialInboxes.find(
+    i => i.id === senderInboxId.value
+  );
+});
+
 const canSave = computed(() => {
   return (
     senderInboxId.value &&
+    !editingDisconnectedInbox.value &&
     receiverAddress.value.trim() &&
     messageTemplate.value.trim() &&
     hasContentSummary.value
@@ -237,6 +251,13 @@ defineExpose({ open });
             {{ formatInboxLabel(inbox) }}
           </option>
         </select>
+        <p
+          v-if="editingDisconnectedInbox"
+          class="mt-1 text-xs text-slate-500 dark:text-slate-400 flex items-start gap-1.5"
+        >
+          <span class="i-lucide-triangle-alert size-3.5 flex-shrink-0 mt-0.5" />
+          <span>{{ $t('AGENT_MGMT.NOTIFICATION.INBOX_DISCONNECTED_WARNING') }}</span>
+        </p>
       </div>
 
       <!-- Category Notification - Dropdown -->

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/notification-settings/NotificationSettings.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/notification-settings/NotificationSettings.vue
@@ -69,11 +69,15 @@ const notifications = useMapGetter(
 );
 const uiFlags = useMapGetter('agentNotificationSettings/getUIFlags');
 
-const whatsappUnofficialInboxes = computed(() => {
+const allWhatsappUnofficialInboxes = computed(() => {
   return (allInboxes.value || []).filter(
-    inbox =>
-      inbox.channel_type === INBOX_TYPES.WHATSAPP_UNOFFICIAL &&
-      inbox.whatsapp_status === 'connected'
+    inbox => inbox.channel_type === INBOX_TYPES.WHATSAPP_UNOFFICIAL
+  );
+});
+
+const whatsappUnofficialInboxes = computed(() => {
+  return allWhatsappUnofficialInboxes.value.filter(
+    inbox => inbox.whatsapp_status === 'connected'
   );
 });
 
@@ -164,24 +168,29 @@ const handleFormClose = () => {
         </div>
       </div>
       <!-- Add Notification Button -->
-      <div class="flex flex-col items-end">
-        <Button
-          :label="$t('AGENT_MGMT.NOTIFICATION.ADD_BUTTON')"
-          class="bg-green-600 rounded-md hover:bg-green-700 disabled:bg-gray-400"
-          size="sm"
-          :disabled="!hasInboxes"
-          @click="openAddForm"
-        />
-        <p
-          v-if="!hasInboxes"
-          class="mt-1 text-xs text-slate-500 dark:text-slate-400 italic"
-        >
-          {{ $t('AGENT_MGMT.NOTIFICATION.NO_INBOX_AVAILABLE') }}
-        </p>
-      </div>
+      <Button
+        :label="$t('AGENT_MGMT.NOTIFICATION.ADD_BUTTON')"
+        class="bg-green-600 rounded-md hover:bg-green-700 disabled:bg-gray-400 shrink-0"
+        size="sm"
+        :disabled="!hasInboxes"
+        @click="openAddForm"
+      />
     </div>
 
-    <div class="border-t border-blue-200 dark:border-blue-700 pt-4">
+    <!-- No Inbox Warning -->
+    <div
+      v-if="!hasInboxes"
+      class="flex items-start gap-2 mt-3 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-md"
+    >
+      <span
+        class="i-lucide-triangle-alert w-4 h-4 text-slate-500 dark:text-slate-400 shrink-0 mt-0.5"
+      />
+      <p class="text-sm text-slate-500 dark:text-slate-400">
+        {{ $t('AGENT_MGMT.NOTIFICATION.NO_INBOX_AVAILABLE') }}
+      </p>
+    </div>
+
+    <div class="border-t border-blue-200 dark:border-blue-700 pt-4 mt-4">
 
       <!-- Loading State -->
       <div
@@ -201,6 +210,7 @@ const handleFormClose = () => {
           :key="rule.id"
           :rule="rule"
           :whatsapp-unofficial-inboxes="whatsappUnofficialInboxes"
+          :all-whatsapp-unofficial-inboxes="allWhatsappUnofficialInboxes"
           :whatsapp-groups="[]"
           @edit="openEditForm"
           @delete="handleDelete"
@@ -219,6 +229,7 @@ const handleFormClose = () => {
       ref="formModalRef"
       :rule="editingRule"
       :whatsapp-unofficial-inboxes="whatsappUnofficialInboxes"
+      :all-whatsapp-unofficial-inboxes="allWhatsappUnofficialInboxes"
       :categories="categories"
       :priorities="priorities"
       :variable-config="variableConfig"


### PR DESCRIPTION
## Description

1. Improve notification settings UX by correctly handling disconnected inboxes in edit existing notification settings card and form
2. Fix layout and overflow warning issues in notification card
3. Align sender/receiver information heights in notification card 
4. Add expand/collapse button to notification cards

<img width="1265" height="703" alt="image" src="https://github.com/user-attachments/assets/97c6979c-5190-4048-ab48-d6f5e9351de1" />

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

* Manually tested notification settings with:

  * Add connected and disconnected WhatsApp unofficial inboxes
  * Add new notification settings
  * Disconnect the WhatsApp unofficial inbox tied to the newly created notification settings.
  * Verify the sender inbox in notification card and edit form, shown correctly with the tied WhatsApp unofficial inbox information
  * Verify the expand/collapse button behavior and sender/receiver card height alignment in the UI

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented on my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules