### PR TITLE
fix: add on delete cascade migration to inbox FK to auto remove dependent records

### DIFF
--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -73,6 +73,7 @@ class Inbox < ApplicationRecord
   has_one :ai_agent, through: :agent_bot_inbox
 
   has_many :reminders, dependent: :delete_all
+  has_many :agent_notification_settings, dependent: :delete_all
   has_many :webhooks, dependent: :destroy_async
   has_many :hooks, dependent: :destroy_async, class_name: 'Integrations::Hook'
 

--- a/db/migrate/20260218000000_add_cascade_delete_to_reminders_fk.rb
+++ b/db/migrate/20260218000000_add_cascade_delete_to_reminders_fk.rb
@@ -1,0 +1,9 @@
+class AddCascadeDeleteToRemindersFk < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :reminders, :inboxes
+    add_foreign_key :reminders, :inboxes, on_delete: :cascade
+
+    remove_foreign_key :reminders, :conversations
+    add_foreign_key :reminders, :conversations, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260218100000_add_cascade_delete_to_agent_notification_settings_fk.rb
+++ b/db/migrate/20260218100000_add_cascade_delete_to_agent_notification_settings_fk.rb
@@ -1,0 +1,6 @@
+class AddCascadeDeleteToAgentNotificationSettingsFk < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :agent_notification_settings, :inboxes
+    add_foreign_key :agent_notification_settings, :inboxes, on_delete: :cascade
+  end
+end


### PR DESCRIPTION
# Pull Request

## Description

Add `ON DELETE CASCADE` to the `reminders` & `agent_notification_settings` → inboxes` foreign key so dependent reminders / agent notification settings are automatically removed when an inbox is deleted, preventing foreign key violations during inbox deletion.
This matches the expected behavior that reminders are removed when its inbox is deleted.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* Reproduced the failure by deleting an inbox with existing reminders (FK violation).
* Applied the migration and retried the delete; inbox and related reminders are removed successfully.
* Verified no orphaned reminder records remain in the database.

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented on my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules