### PR TITLE
fix: disable bot configuration form inputs on save or delete

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/aiagents/AiAgentGeneralSettingsView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/AiAgentGeneralSettingsView.vue
@@ -279,7 +279,7 @@ function resetChat() {
             <Input
               id="name"
               v-model="state.name"
-              :disabled="isDebugMode"
+              :disabled="isDebugMode || loadingSave"
               :placeholder="t('AGENT_MGMT.FORM_CREATE.AI_AGENT_NAME')"
             />
           </div>
@@ -301,7 +301,7 @@ function resetChat() {
           <TextArea
             id="instruction"
             v-model="state.instructions"
-            :disabled="isDebugMode"
+            :disabled="isDebugMode || loadingSave"
             custom-text-area-wrapper-class=""
             custom-text-area-class="!outline-none"
             :placeholder="t('AGENT_MGMT.FORM_CREATE.INSTRUCTION_PLACEHOLDER')"
@@ -326,7 +326,7 @@ function resetChat() {
                 "
                 id="welcome_message"
                 v-model="state.welcoming_message"
-                :disabled="isDebugMode"
+                :disabled="isDebugMode || loadingSave"
                 custom-text-area-wrapper-class=""
                 custom-text-area-class="!outline-none"
                 auto-height
@@ -341,7 +341,7 @@ function resetChat() {
               <TextArea
                 id="business_info"
                 v-model="state.business_info"
-                :disabled="isDebugMode"
+                :disabled="isDebugMode || loadingSave"
                 custom-text-area-wrapper-class=""
                 custom-text-area-class="!outline-none"
                 auto-height
@@ -365,7 +365,7 @@ function resetChat() {
               <input
                 type="checkbox"
                 v-model="state.enable_handover"
-                :disabled="isDebugMode"
+                :disabled="isDebugMode || loadingSave"
                 class="sr-only peer"
               />
               <div
@@ -384,7 +384,7 @@ function resetChat() {
             <TextArea
               id="routing_conditions"
               v-model="state.routing_conditions"
-              :disabled="isDebugMode"
+              :disabled="isDebugMode || loadingSave"
               custom-text-area-wrapper-class=""
               custom-text-area-class="!outline-none"
               :placeholder="

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
@@ -826,7 +826,7 @@ onMounted(async () => {
                       </div>
                       
                       <label class="inline-flex items-center cursor-pointer">
-                        <input type="checkbox" v-model="followUpConfig.enabled" class="sr-only peer">
+                        <input type="checkbox" v-model="followUpConfig.enabled" :disabled="isSaving" class="sr-only peer">
                         <div class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full">
                         </div>
                       </label>
@@ -841,10 +841,11 @@ onMounted(async () => {
                           {{ $t('AGENT_MGMT.REMINDER.TIME') }}
                         </label>
                         <div class="flex items-center gap-3">
-                          <select 
+                          <select
                             v-model="followUpConfig.delay"
+                            :disabled="isSaving"
                             class="text-center w-24 mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed dark:bg-slate-900 dark:border-slate-700 dark:text-white"
-                          > 
+                          >
                             <option 
                               class="bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" 
                               v-for="opt in followUpTimeOptions" 
@@ -868,9 +869,10 @@ onMounted(async () => {
                           </label>
 
                           <div class="relative">
-                            <button 
+                            <button
                               @click="showVariableDropdown = !showVariableDropdown"
                               type="button"
+                              :disabled="isSaving"
                               class="text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 flex items-center gap-1 px-2 py-1 rounded hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
                             >
                               <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
@@ -894,9 +896,10 @@ onMounted(async () => {
                           </div>
                         </div>
 
-                        <textarea 
+                        <textarea
                           ref="followUpTextarea"
                           v-model="followUpConfig.message"
+                          :disabled="isSaving"
                           @click="updateCursorPosition"
                           @keyup="updateCursorPosition"
                           @blur="updateCursorPosition"
@@ -935,8 +938,9 @@ onMounted(async () => {
                     <div class="border-t border-gray-200 dark:border-gray-700 p-6">
                       <label class="block text-sm font-medium mb-1 text-slate-900 dark:text-slate-25">Skala Kreativitas</label>
                       <div class="relative">
-                        <select 
-                          v-model="creativityLevel" 
+                        <select
+                          v-model="creativityLevel"
+                          :disabled="isSaving"
                           class="w-full mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed dark:bg-slate-900 dark:border-slate-700 dark:text-white"
                         >
                           <option class="bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" v-for="opt in creativityOptions" :key="opt.value" :value="opt.value">
@@ -973,6 +977,7 @@ onMounted(async () => {
                         </label>
                         <select
                           v-model="idleConfig.duration"
+                          :disabled="isSaving"
                           class="text-center w-24 mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed dark:bg-slate-900 dark:border-slate-700 dark:text-white"
                         >
                           <option :value="5">{{ $t('AGENT_MGMT.EOBOT.IDLE_TIME_OPTION_5_MIN') }}</option>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/LeadGenBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/LeadGenBotView.vue
@@ -251,7 +251,7 @@
                   </div>
                   
                   <label class="inline-flex items-center cursor-pointer">
-                    <input type="checkbox" v-model="followUpConfig.enabled" class="sr-only peer">
+                    <input type="checkbox" v-model="followUpConfig.enabled" class="sr-only peer" :disabled="isSaving">
                     <div class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full">
                     </div>
                   </label>
@@ -266,10 +266,11 @@
                       {{ $t('AGENT_MGMT.REMINDER.TIME') }}
                     </label>
                     <div class="flex items-center gap-3">
-                      <select 
+                      <select
                         v-model="followUpConfig.delay"
                         class="text-center w-24 mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed dark:bg-slate-900 dark:border-slate-700 dark:text-white"
-                      > 
+                        :disabled="isSaving"
+                      >
                         <option 
                           class="bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" 
                           v-for="opt in followUpTimeOptions" 
@@ -293,9 +294,10 @@
                       </label>
 
                       <div class="relative">
-                        <button 
+                        <button
                           @click="showVariableDropdown = !showVariableDropdown"
                           type="button"
+                          :disabled="isSaving"
                           class="text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 flex items-center gap-1 px-2 py-1 rounded hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
                         >
                           <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
@@ -319,9 +321,10 @@
                       </div>
                     </div>
 
-                    <textarea 
+                    <textarea
                       ref="followUpTextarea"
                       v-model="followUpConfig.message"
+                      :disabled="isSaving"
                       @click="updateCursorPosition"
                       @keyup="updateCursorPosition"
                       @blur="updateCursorPosition"
@@ -360,8 +363,9 @@
                 <div class="border-t border-gray-200 dark:border-gray-700 p-6">
                   <label class="block text-sm font-medium mb-1 text-slate-900 dark:text-slate-25">Skala Kreativitas</label>
                   <div class="relative">
-                    <select 
-                      v-model="creativityLevel" 
+                    <select
+                      v-model="creativityLevel"
+                      :disabled="isSaving"
                       class="w-full mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed dark:bg-slate-900 dark:border-slate-700 dark:text-white"
                     >
                       <option class="bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" v-for="opt in creativityOptions" :key="opt.value" :value="opt.value">
@@ -398,6 +402,7 @@
                     </label>
                     <select
                       v-model="idleConfig.duration"
+                      :disabled="isSaving"
                       class="text-center w-24 mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed dark:bg-slate-900 dark:border-slate-700 dark:text-white"
                     >
                       <option :value="5">{{ $t('AGENT_MGMT.EOBOT.IDLE_TIME_OPTION_5_MIN') }}</option>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
@@ -263,8 +263,9 @@
                   <div class="border-t border-gray-200 dark:border-gray-700 p-6">
                     <label class="block text-sm font-medium mb-1 text-slate-900 dark:text-slate-25">Skala Kreativitas</label>
                     <div class="relative">
-                      <select 
-                        v-model="creativityLevel" 
+                      <select
+                        v-model="creativityLevel"
+                        :disabled="isSaving"
                         class="w-full mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed"
                       >
                         <option class="bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" v-for="opt in creativityOptions" :key="opt.value" :value="opt.value">
@@ -301,6 +302,7 @@
                       </label>
                       <select
                         v-model="idleConfig.duration"
+                        :disabled="isSaving"
                         class="text-center w-24 mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed dark:bg-slate-900 dark:border-slate-700 dark:text-white"
                       >
                         <option :value="5">{{ $t('AGENT_MGMT.EOBOT.IDLE_TIME_OPTION_5_MIN') }}</option>
@@ -1184,7 +1186,7 @@
                           </div>
                         </div>
                         <label class="inline-flex items-center cursor-pointer">
-                          <input type="checkbox" v-model="paymentMethods.cod" class="sr-only peer">
+                          <input type="checkbox" v-model="paymentMethods.cod" :disabled="isSaving" class="sr-only peer">
                           <div
                             class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full">
                           </div>
@@ -1205,7 +1207,7 @@
                           </div>
                         </div>
                         <label class="inline-flex items-center cursor-pointer">
-                          <input type="checkbox" v-model="paymentMethods.bankTransfer" class="sr-only peer">
+                          <input type="checkbox" v-model="paymentMethods.bankTransfer" :disabled="isSaving" class="sr-only peer">
                           <div
                             class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full">
                           </div>
@@ -1231,6 +1233,7 @@
                                 color="ruby"
                                 icon="i-lucide-trash"
                                 size="sm"
+                                :disabled="isSaving"
                                 @click="() => deleteBankAccount(index)"
                                 class="opacity-70 hover:opacity-100"
                               />
@@ -1244,6 +1247,7 @@
                                 <input
                                   type="text"
                                   v-model="account.bankName"
+                                  :disabled="isSaving"
                                   placeholder="e.g., Bank BCA, Bank Mandiri"
                                   class="border-n-weak dark:border-n-weak hover:border-n-slate-6 dark:hover:border-n-slate-6 disabled:border-n-weak dark:disabled:border-n-weak focus:border-n-brand dark:focus:border-n-brand block w-full reset-base text-sm h-10 !px-3 !py-2.5 !mb-0 border rounded-lg bg-n-alpha-black2 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-n-slate-10 dark:placeholder:text-n-slate-10 disabled:cursor-not-allowed disabled:opacity-50 text-n-slate-12 transition-all duration-500 ease-in-out"
                                 />
@@ -1255,6 +1259,7 @@
                                 <input
                                   type="text"
                                   v-model="account.accountNumber"
+                                  :disabled="isSaving"
                                   placeholder="e.g., 1234567890"
                                   class="border-n-weak dark:border-n-weak hover:border-n-slate-6 dark:hover:border-n-slate-6 disabled:border-n-weak dark:disabled:border-n-weak focus:border-n-brand dark:focus:border-n-brand block w-full reset-base text-sm h-10 !px-3 !py-2.5 !mb-0 border rounded-lg bg-n-alpha-black2 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-n-slate-10 dark:placeholder:text-n-slate-10 disabled:cursor-not-allowed disabled:opacity-50 text-n-slate-12 transition-all duration-500 ease-in-out"
                                 />
@@ -1266,6 +1271,7 @@
                                 <input
                                   type="text"
                                   v-model="account.accountHolder"
+                                  :disabled="isSaving"
                                   placeholder="e.g., John Doe"
                                   class="border-n-weak dark:border-n-weak hover:border-n-slate-6 dark:hover:border-n-slate-6 disabled:border-n-weak dark:disabled:border-n-weak focus:border-n-brand dark:focus:border-n-brand block w-full reset-base text-sm h-10 !px-3 !py-2.5 !mb-0 border rounded-lg bg-n-alpha-black2 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-n-slate-10 dark:placeholder:text-n-slate-10 disabled:cursor-not-allowed disabled:opacity-50 text-n-slate-12 transition-all duration-500 ease-in-out"
                                 />
@@ -1274,9 +1280,10 @@
                           </div>
                         </div>
   
-                        <Button 
-                          class="w-full py-3 border-2 border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-green-400 hover:text-green-600 transition-all duration-200 rounded-xl bg-transparent hover:bg-green-50 dark:hover:bg-green-900/10" 
+                        <Button
+                          class="w-full py-3 border-2 border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-green-400 hover:text-green-600 transition-all duration-200 rounded-xl bg-transparent hover:bg-green-50 dark:hover:bg-green-900/10"
                           variant="ghost"
+                          :disabled="isSaving"
                           @click="addBankAccount"
                         >
                           <span class="flex items-center gap-2">
@@ -1302,7 +1309,7 @@
                           </div>
                         </div>
                         <label class="inline-flex items-center cursor-pointer">
-                          <input type="checkbox" v-model="paymentMethods.qris" class="sr-only peer">
+                          <input type="checkbox" v-model="paymentMethods.qris" :disabled="isSaving" class="sr-only peer">
                           <div
                             class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full">
                           </div>
@@ -1323,6 +1330,7 @@
                               color="ruby"
                               icon="i-lucide-trash"
                               size="sm"
+                              :disabled="isSaving"
                               @click="deleteQrisImage"
                               class="opacity-70 hover:opacity-100"
                             />
@@ -1338,11 +1346,13 @@
                                 type="file"
                                 ref="qrisImageInput"
                                 accept="image/*"
+                                :disabled="isSaving"
                                 @change="handleQrisImageUpload"
                                 class="hidden"
                               />
                               <button
                                 @click="$refs.qrisImageInput?.click()"
+                                :disabled="isSaving"
                                 class="px-4 py-2 border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-lg text-slate-600 dark:text-slate-400 hover:border-green-400 hover:text-green-600 transition-all bg-white dark:bg-slate-800"
                               >
                                 {{ qrisConfig.imageUrl ? $t('AGENT_MGMT.SALESBOT.PAYMENT.QRIS_CHANGE_IMAGE') : $t('AGENT_MGMT.SALESBOT.PAYMENT.QRIS_UPLOAD_IMAGE') }}
@@ -1373,7 +1383,7 @@
                           </div>
                         </div>
                         <label class="inline-flex items-center cursor-pointer">
-                          <input type="checkbox" v-model="paymentMethods.paymentGateway" class="sr-only peer">
+                          <input type="checkbox" v-model="paymentMethods.paymentGateway" :disabled="isSaving" class="sr-only peer">
                           <div
                             class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full">
                           </div>
@@ -1500,7 +1510,7 @@
                           </div>
                         </div>
                         <label class="inline-flex items-center cursor-pointer">
-                          <input type="checkbox" v-model="cartEnabled" class="sr-only peer">
+                          <input type="checkbox" v-model="cartEnabled" :disabled="isSaving" class="sr-only peer">
                           <div
                             class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full">
                           </div>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CategoryTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CategoryTab.vue
@@ -212,7 +212,7 @@ async function save() {
                 color="ruby"
                 icon="i-lucide-trash"
                 size="sm"
-                :disabled="false"
+                :disabled="isSaving"
                 @click.stop="() => removeCategory(index)"
                 class="opacity-70 hover:opacity-100"
               />
@@ -240,6 +240,7 @@ async function save() {
                 </label>
                 <textarea
                   v-model="category.name"
+                  :disabled="isSaving"
                   @blur="validateCategoryName(index)"
                   @input="validateCategoryName(index)"
                     :placeholder="$t(getLocaleKey('CATEGORY_PLACEHOLDER'))"
@@ -266,6 +267,7 @@ async function save() {
                 </label>
                 <textarea
                   v-model="category.condition"
+                  :disabled="isSaving"
                   :placeholder="$t(getLocaleKey('CONDITION_PLACEHOLDER'))"
                   class="w-full px-3 py-2.5 text-sm rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 hover:border-slate-300 dark:hover:border-slate-600 focus:ring-2 focus:ring-green-500/20 focus:border-green-500 transition-all duration-200 resize-none placeholder:text-slate-400 dark:placeholder:text-slate-500"
                   rows="3"
@@ -276,10 +278,11 @@ async function save() {
         </div>
       </div>
 
-      <Button 
-        id="btnAddCategory" 
-        class="w-full py-3 border-2 border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-green-400 hover:text-green-600 transition-all duration-200 rounded-xl bg-transparent hover:bg-green-50 dark:hover:bg-green-900/10" 
+      <Button
+        id="btnAddCategory"
+        class="w-full py-3 border-2 border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-green-400 hover:text-green-600 transition-all duration-200 rounded-xl bg-transparent hover:bg-green-50 dark:hover:bg-green-900/10"
         variant="ghost"
+        :disabled="isSaving"
         @click="addCategory"
       >
         <span class="flex items-center gap-2">

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CustomNumberingTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/CustomNumberingTab.vue
@@ -28,12 +28,14 @@
                 <input
                   v-model="form.format"
                   type="text"
+                  :disabled="loading"
                   class="flex-1 focus:border-transparent placeholder:text-gray-400"
                   :class="inputClass"
                   placeholder="[NUMBER]/[MONTH]/[YEAR]"
                 />
-                <select 
-                  v-model="codeOption" 
+                <select
+                  v-model="codeOption"
+                  :disabled="loading"
                   @change="addCode"
                   class="sm:w-64 cursor-pointer"
                   :class="inputClass"
@@ -61,10 +63,11 @@
                 <label :class="labelClass">
                   {{ $t('AGENT_MGMT.NUMBERING.NUMBER') }} <span class="text-red-500">*</span>
                 </label>
-                <input 
-                  v-model.number="form.currentNumber" 
-                  type="number" 
-                  min="1" 
+                <input
+                  v-model.number="form.currentNumber"
+                  type="number"
+                  min="1"
+                  :disabled="loading"
                   class="w-full"
                   :class="inputClass"
                 />
@@ -78,6 +81,7 @@
                   v-model.number="form.number_digits"
                   type="number"
                   min="3"
+                  :disabled="loading"
                   class="w-full"
                   :class="inputClass"
                 />
@@ -91,6 +95,7 @@
                 <input
                   v-model="form.prefix"
                   type="text"
+                  :disabled="loading"
                   :placeholder="$t('AGENT_MGMT.NUMBERING.PREFIX_EXP')"
                   class="w-full"
                   :class="inputClass"
@@ -105,7 +110,7 @@
               <div class="flex flex-col gap-3">
                 <label v-for="opt in resetOptions" :key="opt.value" class="flex items-center cursor-pointer group">
                   <div class="relative flex items-center">
-                    <input type="radio" v-model="form.resetEvery" :value="opt.value" class="peer sr-only" />
+                    <input type="radio" v-model="form.resetEvery" :value="opt.value" :disabled="loading" class="peer sr-only" />
                     <div class="w-5 h-5 border-2 border-gray-300 dark:border-gray-500 rounded-full peer-checked:border-green-500 peer-checked:bg-green-500 transition-all"></div>
                     <div class="absolute w-2 h-2 bg-white rounded-full left-1.5 top-1.5 opacity-0 peer-checked:opacity-100 transition-all"></div>
                   </div>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/GeneralTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/GeneralTab.vue
@@ -389,7 +389,7 @@ console.log("is ticketAuthError value inside GeneralTab.vue:", !ticketAuthError.
           <label class="block font-medium mb-2">{{ $t('AGENT_MGMT.CSBOT.TICKET.SYSTEM_TITLE') }}</label>
           <p class="text-sm text-gray-500 mb-3">{{ $t('AGENT_MGMT.CSBOT.TICKET.SYSTEM_DESC') }}</p>
           <label class="inline-flex items-center cursor-pointer">
-            <input type="checkbox" v-model="config.ticketSystemActive" class="sr-only peer">
+            <input type="checkbox" v-model="config.ticketSystemActive" :disabled="isSaving" class="sr-only peer">
             <div
               class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full">
             </div>
@@ -403,8 +403,9 @@ console.log("is ticketAuthError value inside GeneralTab.vue:", !ticketAuthError.
         <div v-if="config.ticketSystemActive" class="mb-6">
           <label class="block font-medium mb-2">{{ $t('AGENT_MGMT.CSBOT.TICKET.CREATE_WHEN') }}</label>
           <p class="text-sm text-gray-500 mb-3">{{ $t('AGENT_MGMT.CSBOT.TICKET.CREATE_WHEN_DESC') }}</p>
-          <select 
-            v-model="config.ticketCreateWhen" 
+          <select
+            v-model="config.ticketCreateWhen"
+            :disabled="isSaving"
             class="w-full mb-0 p-2 text-sm  border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed"
           >
             <option value="always">{{ $t('AGENT_MGMT.CSBOT.TICKET.CREATE_ALWAYS') }}</option>
@@ -653,8 +654,9 @@ console.log("is ticketAuthError value inside GeneralTab.vue:", !ticketAuthError.
           <div class="border-t border-gray-200 dark:border-gray-700 p-6">
             <label class="block text-sm font-medium mb-1 text-slate-900 dark:text-slate-25">Skala Kreativitas</label>
             <div class="relative">
-              <select 
-                v-model="creativityLevel" 
+              <select
+                v-model="creativityLevel"
+                :disabled="isSaving"
                 class="w-full mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed"
               >
                 <option class="bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" v-for="opt in creativityOptions" :key="opt.value" :value="opt.value">
@@ -690,6 +692,7 @@ console.log("is ticketAuthError value inside GeneralTab.vue:", !ticketAuthError.
               </label>
               <select
                 v-model="idleConfig.duration"
+                :disabled="isSaving"
                 class="text-center w-24 mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed dark:bg-slate-900 dark:border-slate-700 dark:text-white"
               >
                 <option :value="5">{{ $t('AGENT_MGMT.EOBOT.IDLE_TIME_OPTION_5_MIN') }}</option>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/PrioritiesTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/PrioritiesTab.vue
@@ -235,7 +235,7 @@ async function save() {
                 color="ruby"
                 icon="i-lucide-trash"
                 size="sm"
-                :disabled="false"
+                :disabled="isSaving"
                 @click.stop="() => removePriority(index)"
                 class="opacity-70 hover:opacity-100"
               />
@@ -263,6 +263,7 @@ async function save() {
                 </label>
                 <textarea
                   v-model="priority.name"
+                  :disabled="isSaving"
                   @blur="validatePriorityName(index)"
                   @input="validatePriorityName(index)"
                   :placeholder="$t(config.nameLabel)"
@@ -289,6 +290,7 @@ async function save() {
                 </label>
                 <textarea
                   v-model="priority.condition"
+                  :disabled="isSaving"
                   :placeholder="$t(config.conditionPlaceholder)"
                   class="w-full px-3 py-2.5 text-sm rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 hover:border-slate-300 dark:hover:border-slate-600 focus:ring-2 focus:ring-green-500/20 focus:border-green-500 transition-all duration-200 resize-none placeholder:text-slate-400 dark:placeholder:text-slate-500"
                   rows="3"
@@ -299,10 +301,11 @@ async function save() {
         </div>
       </div>
 
-      <Button 
-        id="btnAddPriority" 
-        class="w-full py-3 border-2 border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-green-400 hover:text-green-600 transition-all duration-200 rounded-xl bg-transparent hover:bg-green-50 dark:hover:bg-green-900/10" 
+      <Button
+        id="btnAddPriority"
+        class="w-full py-3 border-2 border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-green-400 hover:text-green-600 transition-all duration-200 rounded-xl bg-transparent hover:bg-green-50 dark:hover:bg-green-900/10"
         variant="ghost"
+        :disabled="isSaving"
         @click="addPriority"
       >
         <span class="flex items-center gap-2">

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/sales-bot-tabs/ShippingConfig.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/sales-bot-tabs/ShippingConfig.vue
@@ -14,9 +14,10 @@
         </div>
 
         <div>
-          <button 
+          <button
             @click="openAddModal"
-            class="inline-flex items-center gap-2 px-4 py-2.5 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-all font-medium shadow-sm active:scale-95"
+            :disabled="props.isSaving"
+            class="inline-flex items-center gap-2 px-4 py-2.5 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-all font-medium shadow-sm active:scale-95 disabled:opacity-70 disabled:cursor-not-allowed"
           >
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
@@ -48,12 +49,12 @@
               </div>
               
               <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                <button @click="editStore(index)" class="p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors" title="Edit">
+                <button @click="editStore(index)" :disabled="props.isSaving" class="p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed" title="Edit">
                   <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
                   </svg>
                 </button>
-                <button @click="promptDelete(index)" class="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors" title="Hapus">
+                <button @click="promptDelete(index)" :disabled="props.isSaving" class="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed" title="Hapus">
                   <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                   </svg>
@@ -123,7 +124,7 @@
              <p class="mt-1 text-sm text-gray-500 max-w-xs mx-auto">
                {{ $t('AGENT_MGMT.SALESBOT.SHIPPING.EMPTY_STATE_DESC') }}
              </p>
-             <button @click="openAddModal" class="mt-4 text-sm font-medium text-green-600 hover:text-green-700">
+             <button @click="openAddModal" :disabled="props.isSaving" class="mt-4 text-sm font-medium text-green-600 hover:text-green-700 disabled:opacity-50 disabled:cursor-not-allowed">
                 {{ $t('AGENT_MGMT.SALESBOT.SHIPPING.ADD_ADDRESS_EMPTY_BTN') }}
              </button>
           </div>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/knowledge-sources/FileKnowledgeSources.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/knowledge-sources/FileKnowledgeSources.vue
@@ -148,6 +148,7 @@ function addFile(file) {
 }
 
 const isSaving = ref(false);
+const isDeletingAny = computed(() => Object.values(deleteLoadingIds.value).some(Boolean));
 
 async function save() {
   if (!newFiles.value.length) return;
@@ -242,8 +243,9 @@ async function previewFile(item) {
       
       <div
         class="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg px-5 py-10 flex items-center justify-center cursor-pointer hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/10 transition-all"
+        :class="{ 'opacity-50 pointer-events-none cursor-not-allowed': isSaving || isDeletingAny }"
         @click="openPicker"
-        @dragover.prevent="handleDragOver" 
+        @dragover.prevent="handleDragOver"
         @dragleave="handleDragLeave"
         @drop.prevent="handleDrop"
       >
@@ -252,6 +254,7 @@ async function previewFile(item) {
           type="file"
           class="hidden"
           accept=".pdf, .docx"
+          :disabled="isSaving || isDeletingAny"
           @change="onInputChanged"
         />
         <div class="text-center">
@@ -307,6 +310,7 @@ async function previewFile(item) {
               size="sm"
               icon="i-lucide-trash"
               :is-loading="deleteLoadingIds[item.id]"
+              :disabled="deleteLoadingIds[item.id] || isSaving || isDeletingAny"
               @click="() => deleteFile(item)"
             />
           </div>
@@ -349,6 +353,7 @@ async function previewFile(item) {
               color="ruby"
               size="sm"
               icon="i-lucide-trash"
+              :disabled="isSaving || isDeletingAny"
               @click="() => newFiles.splice(index, 1)"
             />
           </div>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/knowledge-sources/QnaKnowledgeSources.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/knowledge-sources/QnaKnowledgeSources.vue
@@ -363,7 +363,7 @@ const getAgentId = () => {
                 icon="i-lucide-trash"
                 size="sm"
                 :is-loading="deleteLoadingIds[item.id]"
-                :disabled="deleteLoadingIds[item.id]"
+                :disabled="deleteLoadingIds[item.id] || isSaving"
                 @click.stop="() => deleteQna(item, index)"
                 class="opacity-70 hover:opacity-100"
               />
@@ -389,10 +389,11 @@ const getAgentId = () => {
                   {{ $t('AGENT_MGMT.QUESTION_LABEL') }} <span class="text-red-500">*</span>
                 </label>
                 <div class="relative">
-                  <TextArea 
+                  <TextArea
                     :model-value="getDisplayQuestion(item)"
-                    showCharacterCount="true" 
-                    :maxLength="maxCharQuestion" 
+                    showCharacterCount="true"
+                    :maxLength="maxCharQuestion"
+                    :disabled="isSaving"
                     :placeholder="$t('AGENT_MGMT.QNA_PLACEHOLDER.QUESTION')"
                     class="w-full"
                     @update:model-value="(value) => updateQuestion(item, value)"
@@ -405,10 +406,11 @@ const getAgentId = () => {
                   {{ $t('AGENT_MGMT.ANSWER_LABEL') }} <span class="text-red-500">*</span>
                 </label>
                 <div class="relative">
-                  <TextArea 
+                  <TextArea
                     :model-value="getDisplayAnswer(item)"
-                    showCharacterCount="true" 
-                    :maxLength="maxCharAnswer" 
+                    showCharacterCount="true"
+                    :maxLength="maxCharAnswer"
+                    :disabled="isSaving"
                     :placeholder="$t('AGENT_MGMT.QNA_PLACEHOLDER.ANSWER')"
                     class="w-full"
                     @update:model-value="(value) => updateAnswer(item, value)"
@@ -427,10 +429,10 @@ const getAgentId = () => {
         </div>
       </div>
 
-      <Button 
-        id="btnAddQna" 
-        :disabled="reachedMaxQnas" 
-        class="w-full py-3 border-2 border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-green-400 hover:text-green-600 transition-all duration-200 rounded-xl bg-transparent hover:bg-green-50 dark:hover:bg-green-900/10 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-slate-300 disabled:hover:text-slate-500 disabled:hover:bg-transparent" 
+      <Button
+        id="btnAddQna"
+        :disabled="reachedMaxQnas || isSaving"
+        class="w-full py-3 border-2 border-dashed border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-green-400 hover:text-green-600 transition-all duration-200 rounded-xl bg-transparent hover:bg-green-50 dark:hover:bg-green-900/10 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-slate-300 disabled:hover:text-slate-500 disabled:hover:bg-transparent"
         variant="ghost"
         @click="addQna"
       >


### PR DESCRIPTION
## Description

Disables all editable inputs, dropdowns, toggles, and action buttons during active save or delete operations across all bot configuration views, preventing users from submitting conflicting changes mid-request

Affected views: General Settings, Booking Bot, LeadGen Bot, Sales Bot (all sub-tabs including Payment and Shipping), CS Bot General Settings, Ticket Categories, Ticket Priorities, File/QnA Knowledge Sources, and Custom Numbering

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual testing on each bot config view:
1. Open bot configuration tab
2. Edit and save
3. Verify all inputs, dropdowns, toggles, and add/delete buttons become non-interactive while the request is in the process
4. Confirm controls re-enable after save completes or fails

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
