### PR TITLE
fix: spreadsheet creation state bot settings

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
@@ -290,7 +290,8 @@
       "SHOW_LESS": "Show less"
     },
     "COMMON": {
-      "REMOVE": "Remove"
+      "REMOVE": "Remove",
+      "LOADING": "Loading..."
     },
     "EDIT": {
       "TITLE": "Edit agent",

--- a/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
@@ -290,7 +290,8 @@
       "SHOW_LESS": "Tampilkan sedikit"
     },
     "COMMON": {
-      "REMOVE": "Hapus"
+      "REMOVE": "Hapus",
+      "LOADING": "Memuat..."
     },
     "EDIT": {
       "TITLE": "Edit Agen",

--- a/app/javascript/dashboard/routes/dashboard/aiagents/AIAgentsSettingsView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/AIAgentsSettingsView.vue
@@ -10,7 +10,7 @@ import BookingBotView from './botconfigs/BookingBotView.vue';
 import SalesBotView from './botconfigs/SalesBotView.vue';
 import LeadGenBotView from './botconfigs/LeadGenBotView.vue';
 import EOBotView from './botconfigs/EOBotView.vue';
-import { onMounted, ref, computed, reactive } from 'vue';
+import { onMounted, ref, computed, reactive, watch } from 'vue';
 import aiAgents from '../../../api/aiAgents';
 import googleSheetsExportAPI from '../../../api/googleSheetsExport';
 import { error } from '@formkit/core/index.cjs';
@@ -375,9 +375,24 @@ const showData = async () => {
   }
 };
 
-onMounted(() => {
-  showData();
+onMounted(async () => {
+  await showData();
   checkGoogleSheetsAuth();
+});
+
+watch(data, async (newData) => {
+  if (
+    newData?.display_flow_data &&
+    googleSheetsAuth.authorized &&
+    !googleSheetsAuth.loading
+  ) {
+    const hasUrls = Object.values(googleSheetsAuth.spreadsheetUrls).some(
+      urls => (urls.input && urls.input !== '') || (urls.output && urls.output !== '')
+    );
+    if (!hasUrls) {
+      await loadSpreadsheetUrls();
+    }
+  }
 });
 </script>
 

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
@@ -610,8 +610,14 @@ onMounted(async () => {
         <div v-show="activeIndex === 0" class="w-full">
           <div class="flex flex-row gap-4">
             <div class="flex-1 min-w-0 flex flex-col justify-stretch">
+              <!-- Loading State -->
+              <div v-if="loading" class="flex flex-col items-center justify-center py-16 gap-4">
+                <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-green-600"></div>
+                <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('AGENT_MGMT.COMMON.LOADING') }}</p>
+              </div>
+
               <!-- Step 1: Google Auth -->
-              <div v-if="bookingStep === 'auth'" class="w-full mx-auto">
+              <div v-else-if="bookingStep === 'auth'" class="w-full mx-auto">
                 <div>
                   <label class="block font-medium mb-1">{{ $t('AGENT_MGMT.BOOKING_BOT.AUTH_LABEL') }}</label>
                   <p class="text-gray-600 dark:text-gray-400 mb-4">

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/LeadGenBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/LeadGenBotView.vue
@@ -52,8 +52,14 @@
         <!-- Tab 0: Catalog Configuration -->
         <div v-show="activeIndex === 0" class="w-full min-w-0">
           <div class="space-y-6">
+            <!-- Loading State -->
+            <div v-if="catalogLoading" class="flex flex-col items-center justify-center py-16 gap-4">
+              <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-green-600"></div>
+              <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('AGENT_MGMT.COMMON.LOADING') }}</p>
+            </div>
+            
             <!-- Google Sheets Auth Flow -->
-            <div v-if="catalogStep === 'auth'" class="gap-6">
+            <div v-else-if="catalogStep === 'auth'" class="gap-6">
               <label class="block font-medium mb-1">{{ $t('AGENT_MGMT.LEADGENBOT.CATALOG.SHEETS_TITLE') }}</label>
               <p class="text-gray-600 dark:text-gray-400">{{ $t('AGENT_MGMT.LEADGENBOT.CATALOG.SHEETS_AUTH_DESC') }}</p>
               <button

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
@@ -52,8 +52,14 @@
           <!-- Catalog Tab -->
           <div v-show="activeTabIndex === 0" class="w-full min-w-0">
             <div class="space-y-6">
+              <!-- Loading State -->
+              <div v-if="catalogLoading" class="flex flex-col items-center justify-center py-16 gap-4">
+                <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-green-600"></div>
+                <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('AGENT_MGMT.COMMON.LOADING') }}</p>
+              </div>
+              
               <!-- Google Sheets Auth Flow -->
-              <div v-if="catalogStep === 'auth'" class="gap-6">
+              <div v-else-if="catalogStep === 'auth'" class="gap-6">
                 <label class="block font-medium mb-1">{{ $t('AGENT_MGMT.SALESBOT.CATALOG.SHEETS_TITLE') }}</label>
                 <p class="text-gray-600 dark:text-gray-400">{{ $t('AGENT_MGMT.SALESBOT.CATALOG.SHEETS_AUTH_DESC') }}</p>
                 <button

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/GeneralTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/GeneralTab.vue
@@ -417,8 +417,14 @@ console.log("is ticketAuthError value inside GeneralTab.vue:", !ticketAuthError.
           <h4 class="text-md font-medium text-slate-900 dark:text-slate-25 mb-3">{{ $t('AGENT_MGMT.CSBOT.COMMON.GOOGLE_SHEETS_TITLE') }}</h4>
           <p class="text-sm text-gray-500 mb-4">{{ $t('AGENT_MGMT.CSBOT.COMMON.CONNECT_SHEETS_DESC') }}</p>
 
+          <!-- Loading State -->
+          <div v-if="ticketLoading" class="flex flex-col items-center justify-center py-16 gap-4">
+            <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-green-600"></div>
+            <p class="text-sm text-slate-500 dark:text-slate-400">{{ $t('AGENT_MGMT.COMMON.LOADING') }}</p>
+          </div>
+          
           <!-- Google Sheets Auth Flow -->
-          <div v-if="ticketStep === 'auth'" class="mb-6">
+          <div v-else-if="ticketStep === 'auth'" class="mb-6">
             <div class="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
               <div class="flex items-center gap-3 mb-3">
                 <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/lead-gen-tabs/GeneralTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/lead-gen-tabs/GeneralTab.vue
@@ -93,7 +93,7 @@ const ticketStep = computed(() => props.googleSheetsAuth.step);
 const ticketLoading = computed(() => props.googleSheetsAuth.loading);
 const ticketAccount = computed(() => props.googleSheetsAuth.account);
 const ticketSheets = computed(() => ({
-  output: props.googleSheetsAuth.spreadsheetUrls.lead_gen.output || ''
+  output: props.googleSheetsAuth.spreadsheetUrls.lead_generation.output || ''
 }));
 const ticketAuthError = computed(() => props.googleSheetsAuth.error);
 


### PR DESCRIPTION
## Description

Two related fixes for bot settings showing the wrong spreadsheet step on load.

**1. Race condition in `AIAgentsSettingsView` (root cause)**

`showData()` and `checkGoogleSheetsAuth()` were called concurrently. Since `checkGoogleSheetsAuth()` → `loadSpreadsheetUrls()` depends on `data.value`, it would silently return early before agent data was ready, leaving `step` stuck at `'auth'`.

Fixed by awaiting `showData()` before calling `checkGoogleSheetsAuth()`:
```js
onMounted(async () => {
  await showData();
  checkGoogleSheetsAuth(); // data.value is now guaranteed
});
```

**2. Loading screen in bot views (defense-in-depth)**

With (1) fixed, `checkGoogleSheetsAuth()` is still async. During that window, bot views render with `step = 'auth'` by default. Added a loading spinner gated on the existing `googleSheetsAuth.loading` flag in `BookingBotView`, `LeadGenBotView`, `SalesBotView`, and `cs-bot-tabs/GeneralTab`, blocking all step UI until data finish fetched. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Open bot settings for an agent that already has Google Sheets configured (Booking / Sales / Lead Gen / CS Bot tab)
2. Observe that on initial load a spinner is displayed briefly instead of the "Connect Google" auth step
3. Once `checkGoogleSheetsAuth()` resolves, the correct step is shown — `sheetConfig` for accounts with existing spreadsheets
4. Verify no regression: accounts without Google auth still land on the `auth` step after loading; accounts authenticated but without sheets land on the `connected` step
5. Verify the loading text renders correctly for both `id` and `en` locales

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
