### PR TITLE
fix: add signature file attachment and current conversation id

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
@@ -177,7 +177,7 @@ useKeyboardEvents(keyboardEvents);
         />
       </div>
       <FileUpload
-        v-if="hasSelectedInbox && !isWhatsappInbox && !hasNoInbox"
+        v-if="!isWhatsappInbox && !hasNoInbox"
         ref="uploadAttachment"
         input-id="composeNewConversationAttachment"
         :size="4096 * 4096"

--- a/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
@@ -103,7 +103,7 @@ const { onFileUpload } = useFileUpload({
         uploading,
         tempId,
       };
-      emit('attachFile', [...props.attachedFiles, newFile]);
+      emit('attachFile', newFile);
     };
   },
   updateAttachment: (tempId, blob) => {

--- a/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
@@ -216,8 +216,8 @@ const handleRemoveSignature = signature => {
   state.message = removeSignature(state.message, signature);
 };
 
-const handleAttachFile = files => {
-  state.attachedFiles = files;
+const handleAttachFile = newFile => {
+  state.attachedFiles.push(newFile);
 };
 
 const handleUpdateAttachment = ({ tempId, blob }) => {

--- a/app/javascript/dashboard/components-next/NewConversation/helpers/composeConversationHelper.js
+++ b/app/javascript/dashboard/components-next/NewConversation/helpers/composeConversationHelper.js
@@ -108,7 +108,7 @@ export const prepareAttachmentPayload = (
 ) => {
   const files = [];
   attachedFiles.forEach(attachment => {
-    if (directUploadsEnabled) {
+    if (directUploadsEnabled && attachment.blobSignedId) {
       files.push(attachment.blobSignedId);
     } else {
       files.push(attachment.resource.file);

--- a/app/javascript/dashboard/components-next/NewConversation/helpers/composeConversationHelper.js
+++ b/app/javascript/dashboard/components-next/NewConversation/helpers/composeConversationHelper.js
@@ -110,7 +110,7 @@ export const prepareAttachmentPayload = (
   attachedFiles.forEach(attachment => {
     if (directUploadsEnabled && attachment.blobSignedId) {
       files.push(attachment.blobSignedId);
-    } else {
+    } else if (attachment.resource?.file) {
       files.push(attachment.resource.file);
     }
   });

--- a/app/javascript/dashboard/composables/useFileUpload.js
+++ b/app/javascript/dashboard/composables/useFileUpload.js
@@ -98,7 +98,7 @@ export const useFileUpload = ({
   };
 
   const onFileUpload = file => {
-    if (globalConfig.value.directUploadsEnabled) {
+    if (globalConfig.value.directUploadsEnabled && currentChat.value?.id) {
       handleDirectFileUpload(file);
     } else {
       handleIndirectFileUpload(file);

--- a/app/javascript/dashboard/mixins/fileUploadMixin.js
+++ b/app/javascript/dashboard/mixins/fileUploadMixin.js
@@ -15,7 +15,7 @@ export default {
   },
   methods: {
     onFileUpload(file) {
-      if (this.globalConfig.directUploadsEnabled) {
+      if (this.globalConfig.directUploadsEnabled && this.currentChat?.id) {
         this.onDirectFileUpload(file);
       } else {
         this.onIndirectFileUpload(file);

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/ConversationForm.vue
@@ -248,9 +248,9 @@ export default {
     },
     setAttachmentPayload(payload) {
       this.attachedFiles.forEach(attachment => {
-        if (this.globalConfig.directUploadsEnabled) {
+        if (this.globalConfig.directUploadsEnabled && attachment.blobSignedId) {
           payload.files.push(attachment.blobSignedId);
-        } else {
+        } else if (attachment.resource?.file) {
           payload.files.push(attachment.resource.file);
         }
       });


### PR DESCRIPTION
## Description

File attachment in the "New Message" compose form on the Contacts page has two issues:

1. The attach file button only appears after selecting an inbox — it should be visible immediately
2. Attaching a file causes an infinite loading state and sends "undefined" as attachment data, resulting in a 500 error (ActiveSupport::MessageVerifier::InvalidSignature)

Root cause: The compose form reuses useFileUpload which attempts a direct upload to a conversation-specific endpoint (/conversations/:id/direct_uploads), but no conversation exists yet. The upload silently fails, leaving blobSignedId as undefined, which then gets serialized as the string "undefined" in the request payload

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Open Contacts page → select a contact → click "Kirim Pesan"
2. Verify the attachment (paperclip) button is visible before selecting an inbox
4. Select an inbox → attach an image file → confirm no stuck loading
5. Type a message → send → verify the message and attachment arrive successfully

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
