### PR TITLE
feat: email quota reminder

### DIFF
--- a/app/jobs/notify_upcoming_expiry_user.rb
+++ b/app/jobs/notify_upcoming_expiry_user.rb
@@ -2,61 +2,12 @@ class NotifyUpcomingExpiryUser < ApplicationJob
   queue_as :default
 
   def perform
-    Rails.logger.info('[NotifyUpcomingExpiryUser] Starting job to process upcoming expiry')
+    Rails.logger.info('[NotifyUpcomingExpiryUser] Starting subscription notification job')
 
-    Timeout.timeout(1.hour.second) do
-      loop do
-        upcoming_expiry_subscriptions = fetch_upcoming_expiry_subscriptions
+    Subscriptions::NotifyExpiryService.new.perform
+    Subscriptions::NotifyMauThresholdService.new.perform
+    Subscriptions::NotifyAiResponseThresholdService.new.perform
 
-        if upcoming_expiry_subscriptions.blank?
-          Rails.logger.info('No more upcoming expiry subscriptions, skipping.')
-          break
-        end
-
-        ActiveRecord::Base.transaction do
-          upcoming_expiry_subscriptions.each do |upcoming_expiry|
-            # Rails.logger.info("id: #{upcoming_expiry.subscriptions.first.id}. last_notify: #{upcoming_expiry.subscriptions.first.last_notify_expiry}. ends_at #{upcoming_expiry.subscriptions.first.ends_at}. Data #{upcoming_expiry.users.first.email}. role #{upcoming_expiry.account_users.first.role}")
-            subscription = Subscription.find_by(id: upcoming_expiry.subscriptions.first.id)
-            next if subscription.nil?
-
-            user = upcoming_expiry.users.first
-
-            SubscriptionNotifierMailer.upcoming_expiry(
-              user.email,
-              subscription.account_id,
-              Time.now.utc.strftime('%d %b %Y'),
-              user.display_name || user.name,
-              subscription.plan_name,
-              subscription.ends_at.strftime('%d %b %Y')
-            ).deliver_later
-            subscription.last_notify_expiry = Time.now.utc
-            subscription.save!
-          end
-
-          next
-        end
-      end
-    rescue Timeout::Error
-      log_error("NotifyUpcomingLoop", "Operation timed out")
-    end
-
-    Rails.logger.info("[NotifyUpcomingExpiryUser] Finished processing upcoming expiry")
-  end
-
-  private
-
-  def fetch_upcoming_expiry_subscriptions
-    Account.joins('left join "subscriptions" on subscriptions.id = "accounts"."active_subscription_id"')
-      .joins('left join "account_users" on "account_users"."account_id" = "accounts"."id"')
-      .joins('left join "users" on "users"."id" = "account_users"."user_id"')
-      .where(subscriptions: { last_notify_expiry: nil })
-      .where('DATE(subscriptions.ends_at) = DATE(?)', 7.days.from_now)
-      .where('"account_users"."role" = ?', AccountUser.roles[:administrator])
-      .where.not(active_subscription_id: nil)
-      .limit(10)
-  end
-
-  def log_error(action, exception)
-    Rails.logger.error("[NotifyUpcomingExpiryUser] #{action} failed for: #{exception.message}")
+    Rails.logger.info('[NotifyUpcomingExpiryUser] Finished subscription notification job')
   end
 end

--- a/app/jobs/reset_subscription_usage_job.rb
+++ b/app/jobs/reset_subscription_usage_job.rb
@@ -13,7 +13,9 @@ class ResetSubscriptionUsageJob < ApplicationJob
       usage.update(
         mau_count: 0,
         ai_responses_count: 0,
-        last_reset_at: Time.current,
+        last_notify_mau_threshold: 0,
+        last_notify_ai_response_threshold: 0,
+        last_reset_at: Time.current
       )
 
       Rails.logger.info("[ResetSubscriptionUsageJob] Reset usage for Subscription ID: #{subscription.id}")

--- a/app/listeners/message_processor.rb
+++ b/app/listeners/message_processor.rb
@@ -142,26 +142,4 @@ module MessageProcessor
     User.find_by(id: agent_id)
   end
 
-  def self.increment_mau_usage(conversation)
-    subscription = Subscription.find_by(account_id: conversation.account_id)
-    usage = SubscriptionUsage.find_or_create_by(subscription_id: subscription.id)
-    unless usage
-      Rails.logger.warn("⚠️ No subscription or usage found for account #{account_id}")
-      return
-    end
-    if usage.exceeded_limits?
-      Rails.logger.warn("MAU limit reached for subscription #{usage.subscription_id}")
-    else
-      usage.increment_mau
-      if subscription.max_mau + subscription.additional_mau - 10 == usage.mau_count
-        accountuser = AccountUser.find_by(account_id: conversation.account_id)
-        user = User.find_by(id: accountuser.user_id)
-
-        SubscriptionNotifierMailer.mau_limit_warning(user, usage.mau_count, subscription.max_mau).deliver_later
-
-        Rails.logger.warn("Sent MAU warning email to #{user.email} for account #{conversation.account_id}")
-      end
-
-    end
-  end
 end

--- a/app/mailers/subscription_notifier_mailer.rb
+++ b/app/mailers/subscription_notifier_mailer.rb
@@ -1,15 +1,4 @@
 class SubscriptionNotifierMailer < ApplicationMailer
-  def mau_limit_warning(user, current_mau, limit)
-    @user = user
-    @current_mau = current_mau
-    @limit = limit
-
-    mail(
-      to: @user.email,
-      subject: "Warning: MAU Limit Nearing (#{@current_mau}/#{@limit})"
-    )
-  end
-
   def upcoming_expiry(email, account_id, payment_date, customer_name, nama_paket, tanggal_expired_paket)
     @account_id = account_id
     @payment_date = payment_date
@@ -19,7 +8,59 @@ class SubscriptionNotifierMailer < ApplicationMailer
 
     mail(
       to: email,
-      subject: "⏰ Paket Anda akan berakhir dalam 7 hari – Yuk, perpanjang sekarang!"
+      subject: "Paket Anda akan berakhir dalam 7 hari - Yuk, perpanjang sekarang!"
     )
+  end
+
+  def mau_threshold_warning(email, customer_name, plan_name, account_id, mau_count, mau_limit, threshold_percentage)
+    @customer_name = customer_name
+    @plan_name = plan_name
+    @account_id = account_id
+    @mau_count = mau_count
+    @mau_limit = mau_limit
+    @threshold_percentage = threshold_percentage
+
+    mail(
+      to: email,
+      subject: mau_subject(threshold_percentage)
+    )
+  end
+
+  def ai_response_threshold_warning(email, customer_name, plan_name, account_id, ai_count, ai_limit, threshold_percentage)
+    @customer_name = customer_name
+    @plan_name = plan_name
+    @account_id = account_id
+    @ai_count = ai_count
+    @ai_limit = ai_limit
+    @threshold_percentage = threshold_percentage
+
+    mail(
+      to: email,
+      subject: ai_response_subject(threshold_percentage)
+    )
+  end
+
+  private
+
+  def mau_subject(threshold)
+    case threshold
+    when 100
+      'Kuota MAU Anda sudah habis - Upgrade paket Anda sekarang'
+    when 90
+      'Penggunaan MAU Anda sudah mencapai 90% - Segera upgrade paket Anda'
+    else
+      "Penggunaan MAU Anda sudah mencapai #{threshold}% - Pertimbangkan untuk upgrade paket Anda"
+    end
+  end
+
+  def ai_response_subject(threshold)
+    case threshold
+    when 100
+      'Kuota AI Response Anda sudah habis - Upgrade paket Anda sekarang'
+    when 90
+      'Penggunaan AI Response Anda sudah mencapai 90% - Segera upgrade paket Anda'
+    else
+      "Penggunaan AI Response Anda sudah mencapai #{threshold}% - Pertimbangkan untuk upgrade paket Anda"
+    end
   end
 end

--- a/app/services/subscriptions/increment_usage_service.rb
+++ b/app/services/subscriptions/increment_usage_service.rb
@@ -11,7 +11,6 @@ class Subscriptions::IncrementUsageService
       log_mau_limit_reached(usage)
     else
       usage.increment_mau
-      notify_mau_threshold_reached(usage) if mau_threshold_reached?(usage)
     end
   end
 
@@ -21,26 +20,10 @@ class Subscriptions::IncrementUsageService
     @subscription ||= Subscription.find_by(account_id: @conversation.account_id, status: 'active')
   end
 
-  def account_user
-    @account_user ||= AccountUser.find_by(account_id: @conversation.account_id)
-  end
-
   def find_or_create_usage
     SubscriptionUsage.find_or_create_by(subscription_id: subscription.id).tap do |u|
-      Rails.logger.warn("⚠️ No subscription or usage found for account #{@conversation.account_id}") unless u
+      Rails.logger.warn("No subscription or usage found for account #{@conversation.account_id}") unless u
     end
-  end
-
-  def mau_threshold_reached?(usage)
-    subscription.max_mau + subscription.additional_mau - 10 == usage.mau_count
-  end
-
-  def notify_mau_threshold_reached(usage)
-    user = User.find_by(id: account_user.user_id)
-
-    SubscriptionNotifierMailer.mau_limit_warning(user, usage.mau_count, subscription.max_mau).deliver_later
-
-    Rails.logger.warn("Sent Notification and Email to account id: #{@conversation.account_id}")
   end
 
   def log_mau_limit_reached(usage)

--- a/app/services/subscriptions/notify_ai_response_threshold_service.rb
+++ b/app/services/subscriptions/notify_ai_response_threshold_service.rb
@@ -1,0 +1,69 @@
+class Subscriptions::NotifyAiResponseThresholdService
+  THRESHOLDS = [75, 90, 100].freeze
+
+  def perform
+    Rails.logger.info('[NotifyAiResponseThresholdService] Starting AI response threshold check')
+
+    Subscription.active.includes(:subscription_usage).find_each do |subscription|
+      process_subscription(subscription)
+    rescue StandardError => e
+      Rails.logger.error("[NotifyAiResponseThresholdService] Error processing subscription #{subscription.id}: #{e.message}")
+    end
+  end
+
+  private
+
+  def process_subscription(subscription)
+    usage = subscription.subscription_usage
+    if usage.nil?
+      Rails.logger.info("[NotifyAiResponseThresholdService] Subscription #{subscription.id}: no usage record, skipping")
+      return
+    end
+
+    total_limit = usage.total_max_ai_responses
+    if total_limit.zero?
+      Rails.logger.info("[NotifyAiResponseThresholdService] Subscription #{subscription.id}: total_max_ai_responses is 0, skipping")
+      return
+    end
+
+    effective_usage = usage.ai_responses_count - usage.additional_ai_response_count
+    percentage = (effective_usage.to_f / total_limit * 100).floor
+    Rails.logger.info("[NotifyAiResponseThresholdService] Subscription #{subscription.id}: #{effective_usage}/#{total_limit} = #{percentage}%")
+
+    highest_crossed = THRESHOLDS.select { |t| percentage >= t }.max
+    if highest_crossed.nil?
+      Rails.logger.info("[NotifyAiResponseThresholdService] Subscription #{subscription.id}: no threshold crossed")
+      return
+    end
+    if highest_crossed <= usage.last_notify_ai_response_threshold
+      Rails.logger.info("[NotifyAiResponseThresholdService] Subscription #{subscription.id}: #{highest_crossed}% already notified")
+      return
+    end
+
+    account = subscription.account
+    administrators = account.administrators
+    if administrators.empty?
+      Rails.logger.info("[NotifyAiResponseThresholdService] Subscription #{subscription.id}: no administrators for account #{account.id}")
+      return
+    end
+
+    Rails.logger.info("[NotifyAiResponseThresholdService] Subscription #{subscription.id}: sending #{highest_crossed}% warning to #{administrators.count} admin(s)")
+    administrators.each do |admin|
+      SubscriptionNotifierMailer.ai_response_threshold_warning(
+        admin.email,
+        admin.display_name || admin.name,
+        subscription.plan_name,
+        subscription.account_id,
+        effective_usage,
+        total_limit,
+        highest_crossed
+      ).deliver_later
+    end
+
+    usage.update!(last_notify_ai_response_threshold: highest_crossed)
+
+    Rails.logger.info(
+      "[NotifyAiResponseThresholdService] Sent #{highest_crossed}% AI response warning for subscription #{subscription.id}"
+    )
+  end
+end

--- a/app/services/subscriptions/notify_expiry_service.rb
+++ b/app/services/subscriptions/notify_expiry_service.rb
@@ -1,0 +1,52 @@
+class Subscriptions::NotifyExpiryService
+  def perform
+    Rails.logger.info('[NotifyExpiryService] Starting expiry notification check')
+
+    Timeout.timeout(1.hour.to_i) do
+      loop do
+        subscriptions = fetch_upcoming_expiry_subscriptions
+        break if subscriptions.blank?
+
+        subscriptions.each do |account|
+          process_expiry_notification(account)
+        end
+      end
+    end
+  rescue Timeout::Error
+    Rails.logger.error('[NotifyExpiryService] Operation timed out')
+  end
+
+  private
+
+  def fetch_upcoming_expiry_subscriptions
+    Account.joins('LEFT JOIN "subscriptions" ON subscriptions.id = "accounts"."active_subscription_id"')
+           .joins('LEFT JOIN "account_users" ON "account_users"."account_id" = "accounts"."id"')
+           .joins('LEFT JOIN "users" ON "users"."id" = "account_users"."user_id"')
+           .where(subscriptions: { last_notify_expiry: nil })
+           .where('DATE(subscriptions.ends_at) = DATE(?)', 7.days.from_now)
+           .where('"account_users"."role" = ?', AccountUser.roles[:administrator])
+           .where.not(active_subscription_id: nil)
+           .limit(10)
+  end
+
+  def process_expiry_notification(account)
+    subscription = Subscription.find_by(id: account.active_subscription_id)
+    return if subscription.nil?
+
+    administrators = account.administrators
+    if administrators.any?
+      administrators.each do |admin|
+        SubscriptionNotifierMailer.upcoming_expiry(
+          admin.email,
+          subscription.account_id,
+          Time.now.utc.strftime('%d %b %Y'),
+          admin.display_name || admin.name,
+          subscription.plan_name,
+          subscription.ends_at.strftime('%d %b %Y')
+        ).deliver_later
+      end
+    end
+
+    subscription.update!(last_notify_expiry: Time.now.utc)
+  end
+end

--- a/app/services/subscriptions/notify_expiry_service.rb
+++ b/app/services/subscriptions/notify_expiry_service.rb
@@ -2,38 +2,24 @@ class Subscriptions::NotifyExpiryService
   def perform
     Rails.logger.info('[NotifyExpiryService] Starting expiry notification check')
 
-    Timeout.timeout(1.hour.to_i) do
-      loop do
-        subscriptions = fetch_upcoming_expiry_subscriptions
-        break if subscriptions.blank?
-
-        subscriptions.each do |account|
-          process_expiry_notification(account)
-        end
-      end
+    Subscription.where(last_notify_expiry: nil)
+                .where('DATE(ends_at) = DATE(?)', 7.days.from_now)
+                .joins(:account)
+                .where.not(accounts: { active_subscription_id: nil })
+                .where('subscriptions.id = accounts.active_subscription_id')
+                .find_each do |subscription|
+      process_expiry_notification(subscription)
+    rescue StandardError => e
+      Rails.logger.error("[NotifyExpiryService] Error processing subscription #{subscription.id}: #{e.message}")
     end
-  rescue Timeout::Error
-    Rails.logger.error('[NotifyExpiryService] Operation timed out')
   end
 
   private
 
-  def fetch_upcoming_expiry_subscriptions
-    Account.joins('LEFT JOIN "subscriptions" ON subscriptions.id = "accounts"."active_subscription_id"')
-           .joins('LEFT JOIN "account_users" ON "account_users"."account_id" = "accounts"."id"')
-           .joins('LEFT JOIN "users" ON "users"."id" = "account_users"."user_id"')
-           .where(subscriptions: { last_notify_expiry: nil })
-           .where('DATE(subscriptions.ends_at) = DATE(?)', 7.days.from_now)
-           .where('"account_users"."role" = ?', AccountUser.roles[:administrator])
-           .where.not(active_subscription_id: nil)
-           .limit(10)
-  end
-
-  def process_expiry_notification(account)
-    subscription = Subscription.find_by(id: account.active_subscription_id)
-    return if subscription.nil?
-
+  def process_expiry_notification(subscription)
+    account = subscription.account
     administrators = account.administrators
+
     if administrators.any?
       administrators.each do |admin|
         SubscriptionNotifierMailer.upcoming_expiry(

--- a/app/services/subscriptions/notify_mau_threshold_service.rb
+++ b/app/services/subscriptions/notify_mau_threshold_service.rb
@@ -1,0 +1,71 @@
+class Subscriptions::NotifyMauThresholdService
+  THRESHOLDS = [80, 90, 100].freeze
+
+  def perform
+    Rails.logger.info('[NotifyMauThresholdService] Starting MAU threshold check')
+
+    count = Subscription.active.count
+    Rails.logger.info("[NotifyMauThresholdService] Found #{count} active subscription(s)")
+    Subscription.active.includes(:subscription_usage).find_each do |subscription|
+      process_subscription(subscription)
+    rescue StandardError => e
+      Rails.logger.error("[NotifyMauThresholdService] Error processing subscription #{subscription.id}: #{e.message}")
+    end
+  end
+
+  private
+
+  def process_subscription(subscription)
+    usage = subscription.subscription_usage
+    if usage.nil?
+      Rails.logger.info("[NotifyMauThresholdService] Subscription #{subscription.id}: no usage record, skipping")
+      return
+    end
+
+    total_limit = usage.total_max_mau
+    if total_limit.zero?
+      Rails.logger.info("[NotifyMauThresholdService] Subscription #{subscription.id}: total_max_mau is 0, skipping")
+      return
+    end
+
+    effective_usage = usage.mau_count - usage.additional_mau_count
+    percentage = (effective_usage.to_f / total_limit * 100).floor
+    Rails.logger.info("[NotifyMauThresholdService] Subscription #{subscription.id}: #{effective_usage}/#{total_limit} = #{percentage}%")
+
+    highest_crossed = THRESHOLDS.select { |t| percentage >= t }.max
+    if highest_crossed.nil?
+      Rails.logger.info("[NotifyMauThresholdService] Subscription #{subscription.id}: no threshold crossed")
+      return
+    end
+    if highest_crossed <= usage.last_notify_mau_threshold
+      Rails.logger.info("[NotifyMauThresholdService] Subscription #{subscription.id}: #{highest_crossed}% already notified (last: #{usage.last_notify_mau_threshold}%)")
+      return
+    end
+
+    account = subscription.account
+    administrators = account.administrators
+    if administrators.empty?
+      Rails.logger.info("[NotifyMauThresholdService] Subscription #{subscription.id}: no administrators found for account #{account.id}")
+      return
+    end
+
+    Rails.logger.info("[NotifyMauThresholdService] Subscription #{subscription.id}: sending #{highest_crossed}% warning to #{administrators.count} admin(s)")
+    administrators.each do |admin|
+      SubscriptionNotifierMailer.mau_threshold_warning(
+        admin.email,
+        admin.display_name || admin.name,
+        subscription.plan_name,
+        subscription.account_id,
+        effective_usage,
+        total_limit,
+        highest_crossed
+      ).deliver_later
+    end
+
+    usage.update!(last_notify_mau_threshold: highest_crossed)
+
+    Rails.logger.info(
+      "[NotifyMauThresholdService] Sent #{highest_crossed}% MAU warning for subscription #{subscription.id}"
+    )
+  end
+end

--- a/app/views/subscription_notifier_mailer/ai_response_threshold_warning.html.erb
+++ b/app/views/subscription_notifier_mailer/ai_response_threshold_warning.html.erb
@@ -2,7 +2,7 @@
 <html lang="id">
 <head>
   <meta charset="UTF-8" />
-  <title>Perpanjang Paket - Jangkau.ai</title>
+  <title>Peringatan Kuota AI Response - Jangkau.ai</title>
 </head>
 <body style="background-color:#f8f9fa; padding:2rem 0; font-family: Arial, sans-serif; margin:0;">
   <div style="max-width:700px; margin:auto; background:#fff; padding:2rem; border:1px solid #dee2e6; border-radius:4px; box-shadow:0 2px 6px rgba(0,0,0,0.05);">
@@ -11,7 +11,7 @@
     <div style="display:flex; justify-content:space-between; align-items:flex-start; margin-bottom:1.5rem;">
       <img src="<%= "#{ENV['FRONTEND_URL']}/assets/images/logo-primary-color.png" %>" alt="Logo Jangkau.ai" style="height:40px;" />
       <div style="text-align:right; width: 100%;">
-        <p style="margin:0;"><%= @payment_date %></p>
+        <p style="margin:0;"><%= Time.now.utc.strftime('%d %b %Y') %></p>
       </div>
     </div>
 
@@ -20,13 +20,26 @@
     <!-- Body -->
     <div style="margin-bottom:1.5rem;">
       <p>Halo <strong><%= @customer_name %></strong>,</p>
-      <p>Kami ingin mengingatkan bahwa paket <%= @nama_paket %> Anda di Jangkau.ai akan berakhir pada <%= @tanggal_expired_paket %>, atau dalam 7 hari lagi.</p>
-      <p>Agar chatbot dan fitur Jangkau lainnya tetap aktif melayani pelanggan Anda, yuk perpanjang sebelum masa aktifnya habis.</p>
-      <p>Klik tombol di bawah untuk memperpanjang layanan 👇</p>
+
+      <% if @threshold_percentage >= 100 %>
+        <p>Kuota <strong>Jawaban AI</strong> pada paket <strong><%= @plan_name %></strong> Anda di Jangkau.ai sudah <strong>habis</strong>.</p>
+        <p>Penggunaan saat ini: <strong><%= @ai_count %> / <%= @ai_limit %></strong></p>
+        <p>Chatbot AI Anda tidak dapat merespons hingga kuota ditambah atau direset. Segera upgrade atau beli tambahan kuota agar layanan AI tetap berjalan.</p>
+      <% elsif @threshold_percentage >= 90 %>
+        <p>Penggunaan <strong>Jawaban AI</strong> pada paket <strong><%= @plan_name %></strong> Anda di Jangkau.ai sudah mencapai <strong><%= @threshold_percentage %>%</strong>.</p>
+        <p>Penggunaan saat ini: <strong><%= @ai_count %> / <%= @ai_limit %></strong></p>
+        <p>Kuota AI Anda hampir habis. Segera upgrade paket atau beli tambahan kuota untuk menghindari gangguan layanan AI.</p>
+      <% else %>
+        <p>Penggunaan <strong>Jawaban AI</strong> pada paket <strong><%= @plan_name %></strong> Anda di Jangkau.ai sudah mencapai <strong><%= @threshold_percentage %>%</strong>.</p>
+        <p>Penggunaan saat ini: <strong><%= @ai_count %> / <%= @ai_limit %></strong></p>
+        <p>Pertimbangkan untuk upgrade paket atau membeli tambahan kuota agar layanan AI chatbot Anda tetap berjalan lancar.</p>
+      <% end %>
+
+      <p>Klik tombol di bawah untuk mengelola langganan Anda:</p>
       <a href="<%= "#{ENV['FRONTEND_URL']}/app/accounts/#{@account_id}/settings/billing" %>" style="text-decoration: none;">
-          <div style="background-color:#198754; color:#fff; text-align:center; padding:0.75rem; border-radius:4px;">
-            Perpanjang Layanan
-          </div>
+        <div style="background-color:#198754; color:#fff; text-align:center; padding:0.75rem; border-radius:4px;">
+          Kelola Langganan
+        </div>
       </a>
     </div>
 
@@ -50,7 +63,7 @@
         <a href="#" style="margin:0 0.5rem;"><img src="https://img.icons8.com/ios-filled/30/4caf50/twitter.png" alt="Twitter" /></a>
         <a href="#" style="margin:0 0.5rem;"><img src="https://img.icons8.com/ios-filled/30/4caf50/youtube-play.png" alt="YouTube" /></a>
         <a href="#" style="margin:0 0.5rem;"><img src="https://img.icons8.com/ios-filled/30/4caf50/internet.png" alt="Website" /></a>
-        <p style="margin-top:1rem; font-size:0.9rem; color:#6c757d;">© 2026 PT. Radya Anugerah Digital. All Rights Reserved</p>
+        <p style="margin-top:1rem; font-size:0.9rem; color:#6c757d;">&copy; 2026 PT. Radya Anugerah Digital. All Rights Reserved</p>
       </div>
     </div>
 

--- a/app/views/subscription_notifier_mailer/mau_limit_warning.html.erb
+++ b/app/views/subscription_notifier_mailer/mau_limit_warning.html.erb
@@ -1,6 +1,0 @@
-<p>Hello <%= h(@user.name) %>,</p>
-
-<p>You are nearing your Monthly Active User (MAU) limit.</p>
-<p>Current usage: <%= @current_mau %> / <%= @limit %></p>
-
-<p><a href="<%= ENV['FRONTEND_URL'] %>/app/accounts/<%= @user.id %>/settings/subscriptions">Manage Subscription</a></p>

--- a/app/views/subscription_notifier_mailer/mau_threshold_warning.html.erb
+++ b/app/views/subscription_notifier_mailer/mau_threshold_warning.html.erb
@@ -2,7 +2,7 @@
 <html lang="id">
 <head>
   <meta charset="UTF-8" />
-  <title>Perpanjang Paket - Jangkau.ai</title>
+  <title>Peringatan Kuota MAU - Jangkau.ai</title>
 </head>
 <body style="background-color:#f8f9fa; padding:2rem 0; font-family: Arial, sans-serif; margin:0;">
   <div style="max-width:700px; margin:auto; background:#fff; padding:2rem; border:1px solid #dee2e6; border-radius:4px; box-shadow:0 2px 6px rgba(0,0,0,0.05);">
@@ -11,7 +11,7 @@
     <div style="display:flex; justify-content:space-between; align-items:flex-start; margin-bottom:1.5rem;">
       <img src="<%= "#{ENV['FRONTEND_URL']}/assets/images/logo-primary-color.png" %>" alt="Logo Jangkau.ai" style="height:40px;" />
       <div style="text-align:right; width: 100%;">
-        <p style="margin:0;"><%= @payment_date %></p>
+        <p style="margin:0;"><%= Time.now.utc.strftime('%d %b %Y') %></p>
       </div>
     </div>
 
@@ -20,13 +20,26 @@
     <!-- Body -->
     <div style="margin-bottom:1.5rem;">
       <p>Halo <strong><%= @customer_name %></strong>,</p>
-      <p>Kami ingin mengingatkan bahwa paket <%= @nama_paket %> Anda di Jangkau.ai akan berakhir pada <%= @tanggal_expired_paket %>, atau dalam 7 hari lagi.</p>
-      <p>Agar chatbot dan fitur Jangkau lainnya tetap aktif melayani pelanggan Anda, yuk perpanjang sebelum masa aktifnya habis.</p>
-      <p>Klik tombol di bawah untuk memperpanjang layanan 👇</p>
+
+      <% if @threshold_percentage >= 100 %>
+        <p>Kuota <strong>Pengguna Aktif Bulanan (MAU)</strong> pada paket <strong><%= @plan_name %></strong> Anda di Jangkau.ai sudah <strong>habis</strong>.</p>
+        <p>Penggunaan saat ini: <strong><%= @mau_count %> / <%= @mau_limit %></strong></p>
+        <p>Chatbot Anda tidak dapat melayani pengguna baru hingga kuota ditambah atau direset. Segera upgrade atau beli tambahan kuota agar layanan tetap berjalan.</p>
+      <% elsif @threshold_percentage >= 90 %>
+        <p>Penggunaan <strong>Pengguna Aktif Bulanan (MAU)</strong> pada paket <strong><%= @plan_name %></strong> Anda di Jangkau.ai sudah mencapai <strong><%= @threshold_percentage %>%</strong>.</p>
+        <p>Penggunaan saat ini: <strong><%= @mau_count %> / <%= @mau_limit %></strong></p>
+        <p>Kuota Anda hampir habis. Segera upgrade paket atau beli tambahan kuota untuk menghindari gangguan layanan.</p>
+      <% else %>
+        <p>Penggunaan <strong>Pengguna Aktif Bulanan (MAU)</strong> pada paket <strong><%= @plan_name %></strong> Anda di Jangkau.ai sudah mencapai <strong><%= @threshold_percentage %>%</strong>.</p>
+        <p>Penggunaan saat ini: <strong><%= @mau_count %> / <%= @mau_limit %></strong></p>
+        <p>Pertimbangkan untuk upgrade paket atau membeli tambahan kuota agar layanan chatbot Anda tetap berjalan lancar.</p>
+      <% end %>
+
+      <p>Klik tombol di bawah untuk mengelola langganan Anda:</p>
       <a href="<%= "#{ENV['FRONTEND_URL']}/app/accounts/#{@account_id}/settings/billing" %>" style="text-decoration: none;">
-          <div style="background-color:#198754; color:#fff; text-align:center; padding:0.75rem; border-radius:4px;">
-            Perpanjang Layanan
-          </div>
+        <div style="background-color:#198754; color:#fff; text-align:center; padding:0.75rem; border-radius:4px;">
+          Kelola Langganan
+        </div>
       </a>
     </div>
 
@@ -50,7 +63,7 @@
         <a href="#" style="margin:0 0.5rem;"><img src="https://img.icons8.com/ios-filled/30/4caf50/twitter.png" alt="Twitter" /></a>
         <a href="#" style="margin:0 0.5rem;"><img src="https://img.icons8.com/ios-filled/30/4caf50/youtube-play.png" alt="YouTube" /></a>
         <a href="#" style="margin:0 0.5rem;"><img src="https://img.icons8.com/ios-filled/30/4caf50/internet.png" alt="Website" /></a>
-        <p style="margin-top:1rem; font-size:0.9rem; color:#6c757d;">© 2026 PT. Radya Anugerah Digital. All Rights Reserved</p>
+        <p style="margin-top:1rem; font-size:0.9rem; color:#6c757d;">&copy; 2026 PT. Radya Anugerah Digital. All Rights Reserved</p>
       </div>
     </div>
 

--- a/db/migrate/20260409000000_add_notify_threshold_to_subscription_usage.rb
+++ b/db/migrate/20260409000000_add_notify_threshold_to_subscription_usage.rb
@@ -1,0 +1,6 @@
+class AddNotifyThresholdToSubscriptionUsage < ActiveRecord::Migration[7.0]
+  def change
+    add_column :subscription_usage, :last_notify_mau_threshold, :integer, default: 0, null: false
+    add_column :subscription_usage, :last_notify_ai_response_threshold, :integer, default: 0, null: false
+  end
+end


### PR DESCRIPTION
## Description

Add escalating email notification system for subscription quota usage (MAU and AI responses) and refactor the existing subscription expiry reminder.

- Send email reminders when subscription expires in 7 days (D-7)
- Send escalating email reminders when MAU usage crosses 80%, 90%, 100% thresholds
- Send escalating email reminders when AI response usage crosses 75%, 90%, 100% thresholds
- Emails sent to all account administrators in Indonesian
- Only the highest crossed threshold is sent per check (no intermediate spam)
- Thresholds reset on monthly usage reset, not on top-up
- Remove existing fragile real-time MAU warning from IncrementUsageService and MessageProcessor

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually triggered NotifyUpcomingExpiryUser job via Sidekiq
- Verified MAU threshold warning email rendered and sent for 80% threshold
- Verified AI response threshold check correctly skips subscriptions below threshold
- Verified escalating behavior: once 80% is notified, re-running job does not re-send until next threshold (90%) is crossed
- Verified ResetSubscriptionUsageJob resets threshold tracking columns to 0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
