### PR TITLE
fix: chat preview links attachments render

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/aiagents/AiAgentGeneralSettingsView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/AiAgentGeneralSettingsView.vue
@@ -57,6 +57,7 @@ const loadingChat = ref(false);
 const chatContainer = ref(null);
 const pendingAttachments = ref([]);
 const fileInput = ref(null);
+const failedImages = ref(new Set());
 
 const state = reactive({
   name: '',
@@ -254,6 +255,10 @@ function toDirectImageUrl(url) {
   } catch {
     return url;
   }
+}
+
+function onImageError(url) {
+  failedImages.value = new Set([...failedImages.value, url]);
 }
 
 function onFileSelected(event) {
@@ -581,12 +586,24 @@ function resetChat() {
                   : 'bg-slate-50 dark:bg-slate-800 text-[#000000] dark:text-white',
               ]"
             >
+              <template v-if="message.imageUrl">
               <img
-                v-if="message.imageUrl"
+                  v-if="!failedImages.has(message.imageUrl)"
                 :src="message.imageUrl"
                 :alt="message.content || 'attachment'"
                 class="max-w-full rounded-lg my-2"
-              />
+                  @error="onImageError(message.imageUrl)"
+                />
+                <a
+                  v-else
+                  :href="message.imageUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-blue-500 underline break-all"
+                >
+                  {{ message.imageUrl }}
+                </a>
+              </template>
               <template v-if="message.attachments?.length">
                 <img
                   v-for="(att, ai) in message.attachments"

--- a/app/javascript/dashboard/routes/dashboard/aiagents/AiAgentGeneralSettingsView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/AiAgentGeneralSettingsView.vue
@@ -19,7 +19,12 @@ import captainTranslator from '../../../api/captainTranslator';
 import MarkdownIt from 'markdown-it';
 import { useRoute } from 'vue-router';
 
-const md = new MarkdownIt();
+const md = new MarkdownIt({ linkify: true });
+md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+  tokens[idx].attrSet('target', '_blank');
+  tokens[idx].attrSet('rel', 'noopener noreferrer');
+  return self.renderToken(tokens, idx, options);
+};
 const route = useRoute();
 
 const props = defineProps({
@@ -593,11 +598,7 @@ function resetChat() {
               </template>
               <div
                 v-if="message.content"
-                v-dompurify-html="
-                  message.role === 'user'
-                    ? message.content.replace(/\n/g, '<br>')
-                    : renderMarkdown(message.content)
-                "
+                v-dompurify-html="renderMarkdown(message.content)"
                 class="chat-message-content"
               />
             </div>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/AiAgentGeneralSettingsView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/AiAgentGeneralSettingsView.vue
@@ -587,11 +587,11 @@ function resetChat() {
               ]"
             >
               <template v-if="message.imageUrl">
-              <img
+                <img
                   v-if="!failedImages.has(message.imageUrl)"
-                :src="message.imageUrl"
-                :alt="message.content || 'attachment'"
-                class="max-w-full rounded-lg my-2"
+                  :src="message.imageUrl"
+                  :alt="message.content || 'attachment'"
+                  class="max-w-full rounded-lg my-2"
                   @error="onImageError(message.imageUrl)"
                 />
                 <a
@@ -739,5 +739,26 @@ function resetChat() {
   max-width: 100%;
   border-radius: 0.5rem;
   margin: 0.5em 0;
+}
+
+.chat-message-content {
+  overflow-wrap: break-word;
+}
+
+.chat-message-content :deep(a) {
+  word-break: break-all;
+}
+
+.chat-message-content :deep(a:hover) {
+  color: #3ecf8e; /* blue-700 */
+}
+
+.bg-green-600 .chat-message-content :deep(a) {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.bg-green-600 .chat-message-content :deep(a:hover) {
+  color: #c8f2de; /* green-200 */
 }
 </style>


### PR DESCRIPTION
## Description

Fix three rendering issues in the AI Agent chat preview component:

1. **Links not clickable** — URLs in both user and bot messages were rendered as plain text. Enabled markdown-it `linkify` and ensured links open in a new tab.
2. **Long URL overflow** — URLs without whitespace overflowed the chat bubble. Added `overflow-wrap` and `word-break` CSS rules.
3. **Broken image for non-image URLs** — Attachment URLs pointing to product pages (not images) rendered as broken `<img>` tags. Added `@error` fallback that swaps broken images for clickable links, matching the behavior of the real conversation flow (`AttachMessageImageJob`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Sent "google.com" as user message → link is now clickable and visible (white text with underline on green bubble)
- Bot response with inline URL → auto-linked, wraps correctly within bubble
- Bot attachment with non-image URL (e.g. `https://www.littlepuff.co/search?q=Bunga+papan&scrollToProduct=artificial-bouquet-3`) → falls back to clickable link instead of broken image
- Bot attachment with valid image URL → still renders as image correctly
- Verified hover effects on links in both user (green) and bot (gray) bubbles
- Tested in both light and dark mode

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
