### PR TITLE
fix: localize salesCategories labels using i18n keys

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/agentMgmt.json
@@ -642,7 +642,16 @@
       "NOTIFICATION": {
         "TITLE": "Internal Team Notification Settings",
         "DESC": "Configure automatic internal notifications when a new order is placed.",
-        "TEMPLATE_HELP": "This message will be sent automatically to your internal team to notify them of new orders."
+        "TEMPLATE_HELP": "This message will be sent automatically to your internal team to notify them of new orders.",
+        "CATEGORIES": {
+          "CART_CREATED": "Cart Created",
+          "CART_UPDATED": "Cart Updated",
+          "CART_DELETED": "Cart Deleted",
+          "ORDER_CREATED": "Order Created",
+          "ORDER_UPDATED": "Order Updated",
+          "ORDER_CANCELED": "Order Canceled",
+          "PAYMENT_CREATED": "Payment Created"
+        }
       }
     },
     "EOBOT": {

--- a/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/id/agentMgmt.json
@@ -451,7 +451,16 @@
       "NOTIFICATION": {
         "TITLE": "Pengaturan Notifikasi Tim Internal",
         "DESC": "Atur notifikasi internal otomatis saat pesanan baru dibuat.",
-        "TEMPLATE_HELP": "Pesan ini akan dikirim otomatis ke tim internal Anda untuk memberitahukan pesanan yang masuk."
+        "TEMPLATE_HELP": "Pesan ini akan dikirim otomatis ke tim internal Anda untuk memberitahukan pesanan yang masuk.",
+        "CATEGORIES": {
+          "CART_CREATED": "Keranjang Dibuat",
+          "CART_UPDATED": "Keranjang Diperbarui",
+          "CART_DELETED": "Keranjang Dihapus",
+          "ORDER_CREATED": "Pesanan Dibuat",
+          "ORDER_UPDATED": "Pesanan Diperbarui",
+          "ORDER_CANCELED": "Pesanan Dibatalkan",
+          "PAYMENT_CREATED": "Pembayaran Dibuat"
+        }
       }
     },
     "EOBOT": {

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
@@ -1889,13 +1889,13 @@ const salesAuthError = computed(() => {
 const notification = ref(null);
 
 const salesCategories = computed(() => [
-  { key: 'cart_created', label: 'Cart Created' },
-  { key: 'cart_updated', label: 'Cart Updated' },
-  { key: 'cart_deleted', label: 'Cart Deleted' },
-  { key: 'order_created', label: 'Order Created' },
-  { key: 'order_updated', label: 'Order Updated' },
-  { key: 'order_canceled', label: 'Order Canceled' },
-  { key: 'payment_created', label: 'Payment Created' },
+  { key: 'cart_created', label: t('AGENT_MGMT.SALESBOT.NOTIFICATION.CATEGORIES.CART_CREATED') },
+  { key: 'cart_updated', label: t('AGENT_MGMT.SALESBOT.NOTIFICATION.CATEGORIES.CART_UPDATED') },
+  { key: 'cart_deleted', label: t('AGENT_MGMT.SALESBOT.NOTIFICATION.CATEGORIES.CART_DELETED') },
+  { key: 'order_created', label: t('AGENT_MGMT.SALESBOT.NOTIFICATION.CATEGORIES.ORDER_CREATED') },
+  { key: 'order_updated', label: t('AGENT_MGMT.SALESBOT.NOTIFICATION.CATEGORIES.ORDER_UPDATED') },
+  { key: 'order_canceled', label: t('AGENT_MGMT.SALESBOT.NOTIFICATION.CATEGORIES.ORDER_CANCELED') },
+  { key: 'payment_created', label: t('AGENT_MGMT.SALESBOT.NOTIFICATION.CATEGORIES.PAYMENT_CREATED') },
 ]);
 
 const salesVariableConfig = computed(() => ({


### PR DESCRIPTION
## Summary
- Replace hardcoded English strings in `salesCategories` computed property with `t()` calls
- Add `SALESBOT.NOTIFICATION.CATEGORIES` keys to English locale (`en/agentMgmt.json`)
- Add `SALESBOT.NOTIFICATION.CATEGORIES` keys to Indonesian locale (`id/agentMgmt.json`)