### PR TITLE
fix: restore portal_members table accidentally removed from schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1109,6 +1109,15 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_12_000001) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  create_table "portal_members", force: :cascade do |t|
+    t.bigint "portal_id"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["portal_id", "user_id"], name: "index_portal_members_on_portal_id_and_user_id", unique: true
+    t.index ["user_id", "portal_id"], name: "index_portal_members_on_user_id_and_portal_id", unique: true
+  end
+
   create_table "portals", force: :cascade do |t|
     t.integer "account_id", null: false
     t.string "name", null: false


### PR DESCRIPTION
## Summary
- Restore `portal_members` table definition yang tidak sengaja terhapus dari `db/schema.rb` pada commit `fe0d98e8b`