### PR TITLE
fix: revamp contacts UI — table view, custom attributes, i18n, sidebar, error handling

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsCard/ContactsCard.vue
@@ -78,7 +78,8 @@ const handleFormUpdate = updatedData => {
   Object.assign(contactData.value, updatedData);
 };
 
-const handleUpdateContact = () => {
+const handleUpdateContact = async () => {
+  await contactsFormRef.value?.flushPendingAttr?.();
   emit('updateContact', contactData.value);
 };
 

--- a/app/javascript/dashboard/components-next/Contacts/ContactsDetailsLayout.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsDetailsLayout.vue
@@ -50,7 +50,7 @@ const handleBreadcrumbClick = () => {
 };
 
 const SIDEBAR_STORAGE_KEY = 'contact_detail_sidebar_open';
-const isSidebarOpen = ref(true);
+const isSidebarOpen = ref(false);
 
 onMounted(() => {
   const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);

--- a/app/javascript/dashboard/components-next/Contacts/ContactsDetailsLayout.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsDetailsLayout.vue
@@ -68,7 +68,8 @@ const toggleSidebar = () => {
     class="flex w-full h-full overflow-hidden justify-evenly bg-n-background"
   >
     <div
-      class="flex flex-col w-full h-full transition-all duration-300 ltr:2xl:ml-56 rtl:2xl:mr-56"
+      class="flex flex-col w-full h-full transition-all duration-300"
+      :class="isSidebarOpen ? 'ltr:2xl:ml-56 rtl:2xl:mr-56' : ''"
     >
       <header class="sticky top-0 z-10 px-6 xl:px-0">
         <div class="w-full mx-auto max-w-[650px]">

--- a/app/javascript/dashboard/components-next/Contacts/ContactsDetailsLayout.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsDetailsLayout.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, useSlots } from 'vue';
+import { computed, onMounted, ref, useSlots } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
@@ -48,6 +48,19 @@ const breadcrumbItems = computed(() => {
 const handleBreadcrumbClick = () => {
   emit('goToContactsList');
 };
+
+const SIDEBAR_STORAGE_KEY = 'contact_detail_sidebar_open';
+const isSidebarOpen = ref(true);
+
+onMounted(() => {
+  const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);
+  if (stored !== null) isSidebarOpen.value = stored === 'true';
+});
+
+const toggleSidebar = () => {
+  isSidebarOpen.value = !isSidebarOpen.value;
+  localStorage.setItem(SIDEBAR_STORAGE_KEY, String(isSidebarOpen.value));
+};
 </script>
 
 <template>
@@ -81,9 +94,24 @@ const handleBreadcrumbClick = () => {
 
     <div
       v-if="slots.sidebar"
-      class="overflow-y-auto justify-end min-w-[200px] w-full py-6 max-w-[440px] border-l border-n-weak bg-n-solid-2"
+      class="flex h-full transition-all duration-300"
+      :class="isSidebarOpen ? 'min-w-[200px] w-full max-w-[440px]' : 'flex-shrink-0'"
     >
-      <slot name="sidebar" />
+      <button
+        v-tooltip="isSidebarOpen ? 'Sembunyikan panel' : 'Tampilkan panel'"
+        class="flex-shrink-0 self-start mt-20 flex items-center justify-center w-5 h-9 border border-r-0 border-n-weak bg-n-solid-1 rounded-l-lg hover:bg-n-alpha-2 transition-colors"
+        @click="toggleSidebar"
+      >
+        <span class="text-sm font-semibold leading-none text-n-slate-11 select-none">
+          {{ isSidebarOpen ? '›' : '‹' }}
+        </span>
+      </button>
+      <div
+        class="h-full overflow-y-auto transition-all duration-300 border-l border-n-weak bg-n-solid-2"
+        :class="isSidebarOpen ? 'flex-1 py-6' : 'w-0 overflow-hidden'"
+      >
+        <slot name="sidebar" />
+      </div>
     </div>
   </section>
 </template>

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -338,12 +338,20 @@ watch(() => props.contactData, prepareStateBasedOnProps, {
   deep: true,
 });
 
+const hasPendingAttr = computed(() => !!newCustomAttrKey.value.trim());
+
+const flushPendingAttr = async () => {
+  if (hasPendingAttr.value) await addCustomAttr();
+};
+
 // Expose state to parent component for avatar upload
 defineExpose({
   state,
   resetValidation,
   isFormInvalid,
   resetForm,
+  flushPendingAttr,
+  hasPendingAttr,
 });
 </script>
 
@@ -490,7 +498,11 @@ defineExpose({
       >
         {{ t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.TITLE') }}
       </span>
-      <div class="flex items-end gap-2 w-full">
+      <div class="flex flex-col gap-1.5 w-full">
+      <div
+        class="flex items-end gap-2 w-full rounded-xl transition-all duration-300"
+        :class="hasPendingAttr ? 'bg-n-amber-3 dark:bg-n-amber-2 ring-1 ring-n-amber-8 p-2.5' : ''"
+      >
         <!-- Key dropdown -->
         <div class="flex flex-col gap-1 flex-1" data-key-dropdown>
           <span class="text-xs text-n-slate-11">
@@ -575,9 +587,31 @@ defineExpose({
           />
         </div>
         <!-- Add button -->
-        <Button size="sm" class="mb-0.5" @click="addCustomAttr">
+        <Button
+          size="sm"
+          class="mb-0.5 transition-all duration-200"
+          :amber="hasPendingAttr"
+          @click="addCustomAttr"
+        >
           <Icon icon="i-lucide-plus" class="size-4" />
         </Button>
+      </div>
+      <Transition
+        enter-active-class="transition-all duration-200 ease-out"
+        enter-from-class="opacity-0 -translate-y-1"
+        enter-to-class="opacity-100 translate-y-0"
+        leave-active-class="transition-all duration-150 ease-in"
+        leave-from-class="opacity-100 translate-y-0"
+        leave-to-class="opacity-0 -translate-y-1"
+      >
+        <p
+          v-if="hasPendingAttr"
+          class="flex items-center gap-1.5 text-xs text-n-amber-11 px-1"
+        >
+          <Icon icon="i-lucide-circle-alert" class="size-3 flex-shrink-0" />
+          Klik <span class="font-semibold">+</span> untuk menambah, atau langsung klik Perbarui kontak
+        </p>
+      </Transition>
       </div>
     </div>
   </div>

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -461,14 +461,14 @@ defineExpose({
         </div>
       </div>
     </div>
-    <div
-      v-if="Object.keys(customAttrsDisplay).length > 0"
-      class="flex flex-col w-full gap-3 p-4 rounded-lg bg-n-alpha-black2"
-    >
+    <div class="flex flex-col w-full gap-3 p-4 rounded-lg bg-n-alpha-black2">
       <span class="text-base font-semibold text-n-slate-12">
         {{ t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.TITLE') }}
       </span>
-      <div class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
+      <div
+        v-if="Object.keys(customAttrsDisplay).length > 0"
+        class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2"
+      >
         <template v-for="(value, key) in customAttrsDisplay" :key="key">
           <div class="flex flex-col items-start gap-2">
             <span class="text-sm font-medium text-n-slate-12">{{ key }}</span>
@@ -517,14 +517,10 @@ defineExpose({
           </div>
         </template>
       </div>
-    </div>
-    <div class="flex flex-col items-start gap-3">
-      <span
-        v-if="Object.keys(customAttrsDisplay).length === 0"
-        class="py-1 text-sm font-medium text-n-slate-12"
-      >
-        {{ t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.TITLE') }}
-      </span>
+      <div
+        v-if="Object.keys(customAttrsDisplay).length > 0"
+        class="border-t border-n-weak"
+      />
       <div class="flex flex-col gap-1.5 w-full">
       <div
         class="flex items-start gap-2 w-full rounded-xl transition-all duration-300"

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onUnmounted, reactive, ref, watch } from 'vue';
+import { computed, nextTick, onUnmounted, reactive, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { required, email } from '@vuelidate/validators';
 import { useVuelidate } from '@vuelidate/core';
@@ -249,11 +249,11 @@ const newCustomAttrKey = ref('');
 const newCustomAttrValue = ref('');
 const newCustomAttrDataType = ref('text');
 const showKeyDropdown = ref(false);
-const newKeyInput = ref('');
+const keySearchInput = ref('');
+const keySearchInputRef = ref(null);
 
 const customAttrsDisplay = computed(() => state.customAttributes || {});
 
-// Attribute keys defined in the system but not yet added to this contact
 const availableAttributeKeys = computed(() => {
   const existing = Object.keys(customAttrsDisplay.value);
   return (contactAttributeKeys.value || []).filter(
@@ -261,18 +261,45 @@ const availableAttributeKeys = computed(() => {
   );
 });
 
+const filteredAttributeKeys = computed(() => {
+  const search = keySearchInput.value.trim().toLowerCase();
+  if (!search) return availableAttributeKeys.value;
+  return availableAttributeKeys.value.filter(r =>
+    r.key.toLowerCase().includes(search)
+  );
+});
+
+const canCreateNew = computed(() => {
+  const search = keySearchInput.value.trim();
+  if (!search) return false;
+  return !availableAttributeKeys.value.some(r => r.key === search);
+});
+
+const openDropdown = () => {
+  keySearchInput.value = '';
+  showKeyDropdown.value = true;
+  nextTick(() => keySearchInputRef.value?.focus());
+};
+
 const selectExistingKey = r => {
   newCustomAttrKey.value = r.key;
   newCustomAttrDataType.value = r.data_type || 'text';
+  keySearchInput.value = '';
   showKeyDropdown.value = false;
 };
 
 const selectNewKey = () => {
-  if (!newKeyInput.value.trim()) return;
-  newCustomAttrKey.value = newKeyInput.value.trim();
-  newKeyInput.value = '';
+  if (!keySearchInput.value.trim()) return;
+  newCustomAttrKey.value = keySearchInput.value.trim();
+  keySearchInput.value = '';
   showKeyDropdown.value = false;
 };
+
+const dataTypeOptions = computed(() => [
+  { value: 'text', label: t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.DATA_TYPES.TEXT') },
+  { value: 'number', label: t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.DATA_TYPES.NUMBER') },
+  { value: 'date', label: t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.DATA_TYPES.DATE') },
+]);
 
 const setDataType = dt => {
   newCustomAttrDataType.value = dt;
@@ -500,7 +527,7 @@ defineExpose({
       </span>
       <div class="flex flex-col gap-1.5 w-full">
       <div
-        class="flex items-end gap-2 w-full rounded-xl transition-all duration-300"
+        class="flex items-start gap-2 w-full rounded-xl transition-all duration-300"
         :class="hasPendingAttr ? 'bg-n-amber-3 dark:bg-n-amber-2 ring-1 ring-n-amber-8 p-2.5' : ''"
       >
         <!-- Key dropdown -->
@@ -513,56 +540,73 @@ defineExpose({
               type="button"
               class="h-8 w-full px-2 text-sm border border-n-weak rounded-lg bg-n-alpha-black2 text-left flex items-center justify-between gap-1 focus:outline-none focus:border-n-brand"
               :class="newCustomAttrKey ? 'text-n-slate-12' : 'text-n-slate-10'"
-              @click.stop="showKeyDropdown = !showKeyDropdown"
+              @click.stop="openDropdown"
             >
               <span class="truncate">{{ newCustomAttrKey || t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.KEY_PLACEHOLDER') }}</span>
               <Icon icon="i-lucide-chevron-down" class="size-3 flex-shrink-0 text-n-slate-10" />
             </button>
             <div
               v-if="showKeyDropdown"
-              class="absolute top-full left-0 mt-1 w-full min-w-[160px] bg-n-solid-1 border border-n-weak rounded-lg shadow-lg z-50 overflow-hidden"
+              class="absolute top-full left-0 mt-1 w-full min-w-[180px] bg-n-solid-1 border border-n-weak rounded-lg shadow-lg z-50 overflow-hidden"
             >
+              <!-- Search / filter input -->
+              <div class="p-2 border-b border-n-weak">
+                <input
+                  ref="keySearchInputRef"
+                  v-model="keySearchInput"
+                  type="text"
+                  :placeholder="t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.SEARCH_PLACEHOLDER')"
+                  class="h-7 w-full px-2 text-sm border border-n-weak rounded-md bg-n-alpha-black2 text-n-slate-12 placeholder:text-n-slate-10 focus:outline-none focus:border-n-brand"
+                  @click.stop
+                />
+              </div>
+              <!-- Existing filtered options -->
               <div class="max-h-40 overflow-y-auto">
                 <button
-                  v-for="r in availableAttributeKeys"
+                  v-for="r in filteredAttributeKeys"
                   :key="r.key"
                   type="button"
                   class="w-full px-3 py-1.5 text-sm text-left text-n-slate-12 hover:bg-n-alpha-2 flex items-center justify-between gap-2"
                   @click.stop="selectExistingKey(r)"
                 >
                   <span class="truncate">{{ r.key }}</span>
-                  <span class="text-xs text-n-slate-10 flex-shrink-0">{{ r.data_type }}</span>
+                  <span class="text-xs text-n-slate-10 flex-shrink-0">{{ dataTypeOptions.find(d => d.value === r.data_type)?.label ?? r.data_type }}</span>
                 </button>
                 <p
-                  v-if="!availableAttributeKeys.length"
+                  v-if="!filteredAttributeKeys.length && !canCreateNew"
                   class="px-3 py-2 text-xs text-n-slate-10"
                 >
                   {{ t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.NO_AVAILABLE_KEYS') }}
                 </p>
               </div>
-              <div class="border-t border-n-weak p-2 flex flex-col gap-1.5">
-                <input
-                  v-model="newKeyInput"
-                  type="text"
-                  :placeholder="t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.NEW_KEY_PLACEHOLDER')"
-                  class="h-7 w-full px-2 text-sm border border-n-weak rounded-md bg-n-alpha-black2 text-n-slate-12 placeholder:text-n-slate-10 focus:outline-none focus:border-n-brand"
-                  @click.stop
-                  @keyup.enter="selectNewKey"
-                />
-                <div class="flex gap-1" @click.stop>
+              <!-- Create new option — only shown when typed text doesn't match existing -->
+              <div
+                v-if="canCreateNew"
+                class="border-t border-n-weak p-2 flex flex-col gap-1.5"
+                @click.stop
+              >
+                <div class="flex gap-1">
                   <button
-                    v-for="dt in ['text', 'number', 'date']"
-                    :key="dt"
+                    v-for="dt in dataTypeOptions"
+                    :key="dt.value"
                     type="button"
-                    class="flex-1 py-0.5 text-xs rounded border transition-colors"
-                    :class="newCustomAttrDataType === dt
+                    class="flex-1 py-1 text-xs rounded border transition-colors"
+                    :class="newCustomAttrDataType === dt.value
                       ? 'bg-n-brand text-white border-n-brand'
                       : 'border-n-weak text-n-slate-11 hover:bg-n-alpha-2'"
-                    @click="setDataType(dt)"
+                    @click="setDataType(dt.value)"
                   >
-                    {{ dt }}
+                    {{ dt.label }}
                   </button>
                 </div>
+                <button
+                  type="button"
+                  class="w-full flex items-center gap-2 px-2 py-1.5 text-sm rounded-md hover:bg-n-alpha-2 text-n-brand text-left"
+                  @click.stop="selectNewKey"
+                >
+                  <Icon icon="i-lucide-plus" class="size-3.5 flex-shrink-0" />
+                  <span class="truncate">{{ t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.CREATE_NEW', { key: keySearchInput }) }}</span>
+                </button>
               </div>
             </div>
           </div>
@@ -589,7 +633,7 @@ defineExpose({
         <!-- Add button -->
         <Button
           size="sm"
-          class="mb-0.5 transition-all duration-200"
+          class="mt-5 transition-all duration-200"
           :amber="hasPendingAttr"
           @click="addCustomAttr"
         >

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -337,6 +337,7 @@ const addCustomAttr = async () => {
 };
 
 const pendingDeleteKey = ref(null);
+const keyToDeleteGlobally = ref(null);
 
 const handleTrashClick = key => {
   pendingDeleteKey.value = pendingDeleteKey.value === key ? null : key;
@@ -352,7 +353,19 @@ const removeFromContact = key => {
   emit('removeCustomAttr', key);
 };
 
-const removeDefinition = async key => {
+const requestRemoveDefinition = key => {
+  pendingDeleteKey.value = null;
+  keyToDeleteGlobally.value = key;
+};
+
+const cancelRemoveDefinition = () => {
+  keyToDeleteGlobally.value = null;
+};
+
+const confirmRemoveDefinition = async () => {
+  const key = keyToDeleteGlobally.value;
+  if (!key) return;
+  keyToDeleteGlobally.value = null;
   const record = (contactAttributeKeys.value || []).find(r => r.key === key);
   if (record) {
     await store.dispatch('contactAttributeKeys/destroy', record.id);
@@ -502,7 +515,7 @@ defineExpose({
               <button
                 type="button"
                 class="px-2 py-0.5 text-xs rounded bg-n-alpha-black2 text-n-slate-12 hover:bg-n-ruby-4 hover:text-n-ruby-11"
-                @click="removeDefinition(key)"
+                @click="requestRemoveDefinition(key)"
               >
                 {{ t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.DELETE_ALL') }}
               </button>
@@ -517,6 +530,42 @@ defineExpose({
           </div>
         </template>
       </div>
+      <Transition
+        enter-active-class="transition-all duration-200 ease-out"
+        enter-from-class="opacity-0 -translate-y-1"
+        enter-to-class="opacity-100 translate-y-0"
+        leave-active-class="transition-all duration-150 ease-in"
+        leave-from-class="opacity-100 translate-y-0"
+        leave-to-class="opacity-0 -translate-y-1"
+      >
+        <div
+          v-if="keyToDeleteGlobally"
+          class="flex flex-col gap-2 p-3 rounded-lg bg-n-ruby-3 ring-1 ring-n-ruby-7"
+        >
+          <div class="flex items-start gap-2">
+            <Icon icon="i-lucide-triangle-alert" class="size-4 flex-shrink-0 text-n-ruby-11 mt-0.5" />
+            <p class="text-sm text-n-ruby-12">
+              {{ t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.DELETE_ALL_CONFIRM.DESCRIPTION', { key: keyToDeleteGlobally }) }}
+            </p>
+          </div>
+          <div class="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              class="px-3 py-1 text-xs rounded-md border border-n-weak bg-n-solid-1 text-n-slate-12 hover:bg-n-alpha-2 transition-colors"
+              @click="cancelRemoveDefinition"
+            >
+              {{ t('DIALOG.BUTTONS.CANCEL') }}
+            </button>
+            <button
+              type="button"
+              class="px-3 py-1 text-xs rounded-md bg-n-ruby-9 text-white hover:bg-n-ruby-10 transition-colors"
+              @click="confirmRemoveDefinition"
+            >
+              {{ t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.DELETE_ALL_CONFIRM.CONFIRM') }}
+            </button>
+          </div>
+        </div>
+      </Transition>
       <div
         v-if="Object.keys(customAttrsDisplay).length > 0"
         class="border-t border-n-weak"

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -475,7 +475,7 @@ defineExpose({
             <div class="flex items-center w-full gap-2">
               <Input
                 v-model="state.customAttributes[key]"
-                :placeholder="'Masukkan ' + key + ' Anda'"
+                :placeholder="t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.VALUE_WITH_KEY', { key })"
                 class="flex-1"
                 @input="emit('update', state)"
               />
@@ -653,7 +653,7 @@ defineExpose({
           class="flex items-center gap-1.5 text-xs text-n-amber-11 px-1"
         >
           <Icon icon="i-lucide-circle-alert" class="size-3 flex-shrink-0" />
-          Klik <span class="font-semibold">+</span> untuk menambah, atau langsung klik Perbarui kontak
+          {{ t('CONTACTS_LAYOUT.CARD.CUSTOM_ATTRIBUTES.PENDING_HINT') }}
         </p>
       </Transition>
       </div>

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue
@@ -386,7 +386,7 @@ defineExpose({
   <div class="flex flex-col gap-6">
     <div class="flex flex-col items-start gap-2">
       <span class="py-1 text-sm font-medium text-n-slate-12">
-        {{ t('CONTACTS_LAYOUT.CARD.EDIT_DETAILS_FORM.TITLE') }}
+        {{ isNewContact ? t('CONTACTS_LAYOUT.CARD.NEW_CONTACT_FORM.TITLE') : t('CONTACTS_LAYOUT.CARD.EDIT_DETAILS_FORM.TITLE') }}
       </span>
       <div class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
         <template v-for="item in editDetailsForm" :key="item.key">
@@ -433,7 +433,7 @@ defineExpose({
     </div>
     <div class="flex flex-col items-start gap-2">
       <span class="py-1 text-sm font-medium text-n-slate-12">
-        {{ t('CONTACTS_LAYOUT.CARD.SOCIAL_MEDIA.TITLE') }}
+        {{ isNewContact ? t('CONTACTS_LAYOUT.CARD.SOCIAL_MEDIA.TITLE_NEW') : t('CONTACTS_LAYOUT.CARD.SOCIAL_MEDIA.TITLE') }}
       </span>
       <div class="flex flex-wrap gap-2">
         <div

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/CreateNewContactDialog.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/CreateNewContactDialog.vue
@@ -24,6 +24,7 @@ const createNewContact = contactItem => {
 
 const handleDialogConfirm = async () => {
   if (!contact.value) return;
+  await contactsFormRef.value?.flushPendingAttr?.();
   emit('create', contact.value);
 };
 

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/CreateNewContactDialog.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/CreateNewContactDialog.vue
@@ -14,6 +14,7 @@ const { t } = useI18n();
 const dialogRef = ref(null);
 const contactsFormRef = ref(null);
 const contact = ref(null);
+const errorMessage = ref('');
 
 const uiFlags = useMapGetter('contacts/getUIFlags');
 const isCreatingContact = computed(() => uiFlags.value.isCreating);
@@ -29,15 +30,21 @@ const handleDialogConfirm = async () => {
 };
 
 const onSuccess = () => {
+  errorMessage.value = '';
   contactsFormRef.value?.resetForm();
   dialogRef.value.close();
 };
 
+const showError = message => {
+  errorMessage.value = message;
+};
+
 const closeDialog = () => {
+  errorMessage.value = '';
   dialogRef.value.close();
 };
 
-defineExpose({ dialogRef, contactsFormRef, onSuccess });
+defineExpose({ dialogRef, contactsFormRef, onSuccess, showError });
 </script>
 
 <template>
@@ -48,22 +55,27 @@ defineExpose({ dialogRef, contactsFormRef, onSuccess });
       @update="createNewContact"
     />
     <template #footer>
-      <div class="flex items-center justify-between w-full gap-3">
-        <Button
-          :label="t('DIALOG.BUTTONS.CANCEL')"
-          variant="link"
-          class="h-10 hover:!no-underline hover:text-n-brand"
-          @click="closeDialog"
-        />
-        <Button
-          :label="
-            t('CONTACTS_LAYOUT.HEADER.ACTIONS.CONTACT_CREATION.SAVE_CONTACT')
-          "
-          color="blue"
-          :disabled="contactsFormRef?.isFormInvalid"
-          :is-loading="isCreatingContact"
-          @click="handleDialogConfirm"
-        />
+      <div class="flex flex-col w-full gap-2">
+        <p v-if="errorMessage" class="text-sm text-n-ruby-11 text-right">
+          {{ errorMessage }}
+        </p>
+        <div class="flex items-center justify-between w-full gap-3">
+          <Button
+            :label="t('DIALOG.BUTTONS.CANCEL')"
+            variant="link"
+            class="h-10 hover:!no-underline hover:text-n-brand"
+            @click="closeDialog"
+          />
+          <Button
+            :label="
+              t('CONTACTS_LAYOUT.HEADER.ACTIONS.CONTACT_CREATION.SAVE_CONTACT')
+            "
+            color="blue"
+            :disabled="contactsFormRef?.isFormInvalid"
+            :is-loading="isCreatingContact"
+            @click="handleDialogConfirm"
+          />
+        </div>
       </div>
     </template>
   </Dialog>

--- a/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue
@@ -91,17 +91,19 @@ const onCreate = async contact => {
     );
   } catch (error) {
     const i18nPrefix = 'CONTACTS_LAYOUT.HEADER.ACTIONS.CONTACT_CREATION';
+    let message;
     if (error instanceof DuplicateContactException) {
       if (error.data.includes('email')) {
-        useAlert(t(`${i18nPrefix}.EMAIL_ADDRESS_DUPLICATE`));
+        message = t(`${i18nPrefix}.EMAIL_ADDRESS_DUPLICATE`);
       } else if (error.data.includes('phone_number')) {
-        useAlert(t(`${i18nPrefix}.PHONE_NUMBER_DUPLICATE`));
+        message = t(`${i18nPrefix}.PHONE_NUMBER_DUPLICATE`);
       }
     } else if (error instanceof ExceptionWithMessage) {
-      useAlert(error.data);
+      message = error.data;
     } else {
-      useAlert(t(`${i18nPrefix}.ERROR_MESSAGE`));
+      message = t(`${i18nPrefix}.ERROR_MESSAGE`);
     }
+    createNewContactDialogRef.value?.showError(message);
   }
 };
 

--- a/app/javascript/dashboard/components-next/Contacts/ContactsTable/ContactsTable.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsTable/ContactsTable.vue
@@ -79,6 +79,7 @@ const handleRemoveCustomAttr = key => {
 const handleUpdateContact = async () => {
   if (!contactForEdit.value) return;
   try {
+    await contactsFormRef.value?.flushPendingAttr?.();
     if (removedCustomAttrs.value.length > 0) {
       await store.dispatch('contacts/deleteCustomAttributes', {
         id: contactForEdit.value.id,

--- a/app/javascript/dashboard/components-next/Contacts/ContactsTable/ContactsTable.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsTable/ContactsTable.vue
@@ -13,7 +13,9 @@ import Table from 'dashboard/components/table/Table.vue';
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
 import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
+import Flag from 'dashboard/components-next/flag/Flag.vue';
 import ContactsForm from 'dashboard/components-next/Contacts/ContactsForm/ContactsForm.vue';
+import countries from 'shared/constants/countries';
 
 const props = defineProps({
   contacts: { type: Array, required: true },
@@ -100,22 +102,35 @@ const onClickViewDetails = id => {
 
 const formatDate = timestamp => {
   if (!timestamp) return '---';
-  return new Date(timestamp * 1000).toLocaleDateString('id-ID', {
+  return new Date(timestamp * 1000).toLocaleDateString(navigator.language ?? 'id-ID', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
   });
 };
 
+const countriesMap = countries.reduce((acc, c) => {
+  acc[c.id] = c;
+  acc[c.name] = c;
+  return acc;
+}, {});
+
+const getCountryCode = additionalAttributes => {
+  if (!additionalAttributes) return null;
+  const { countryCode, country } = additionalAttributes;
+  const match = countriesMap[countryCode] || countriesMap[country];
+  return match?.id || null;
+};
+
 const formatLocation = additionalAttributes => {
-  if (!additionalAttributes) return '---';
+  if (!additionalAttributes) return null;
   const { country, city } = additionalAttributes;
-  if (!country && !city) return '---';
+  if (!country && !city) return null;
   return [city, country].filter(Boolean).join(', ');
 };
 
 const formatCompanyName = additionalAttributes => {
-  return additionalAttributes?.companyName || '---';
+  return additionalAttributes?.companyName || null;
 };
 
 const columns = computed(() => {
@@ -132,7 +147,7 @@ const columns = computed(() => {
             h(Avatar, { name: contact.name, src: contact.thumbnail, size: 36 }),
             h('div', { class: 'flex flex-col' }, [
               h('span', { class: 'font-medium text-n-slate-12' }, contact.name || '---'),
-              props.visibleColumns.includes('email') && contact.email
+              contact.email
                 ? h('span', { class: 'text-xs text-n-slate-10' }, contact.email)
                 : null,
             ]),
@@ -157,6 +172,7 @@ const columns = computed(() => {
     );
   }
 
+
   if (props.visibleColumns.includes('phoneNumber')) {
     cols.push(
       columnHelper.display({
@@ -178,7 +194,11 @@ const columns = computed(() => {
         header: t('CONTACTS_LAYOUT.TABLE.COLUMN.COMPANY'),
         cell: ({ row }) => {
           const value = formatCompanyName(row.original.additionalAttributes);
-          return h('span', { class: value === '---' ? 'text-n-slate-8' : '' }, value);
+          if (!value) return h('span', { class: 'text-n-slate-8' }, '---');
+          return h('div', { class: 'flex items-center gap-1.5' }, [
+            h('span', { class: 'i-ph-building-light size-3.5 text-n-slate-10 flex-shrink-0' }),
+            h('span', {}, value),
+          ]);
         },
         size: 180,
       })
@@ -192,7 +212,12 @@ const columns = computed(() => {
         header: t('CONTACTS_LAYOUT.TABLE.COLUMN.LOCATION'),
         cell: ({ row }) => {
           const value = formatLocation(row.original.additionalAttributes);
-          return h('span', { class: value === '---' ? 'text-n-slate-8' : '' }, value);
+          if (!value) return h('span', { class: 'text-n-slate-8' }, '---');
+          const code = getCountryCode(row.original.additionalAttributes);
+          return h('div', { class: 'flex items-center gap-1.5' }, [
+            code ? h(Flag, { country: code, class: 'size-3.5 flex-shrink-0' }) : null,
+            h('span', {}, value),
+          ]);
         },
         size: 150,
       })

--- a/app/javascript/dashboard/components-next/Contacts/Pages/ContactDetails.vue
+++ b/app/javascript/dashboard/components-next/Contacts/Pages/ContactDetails.vue
@@ -75,6 +75,7 @@ const handleRemoveCustomAttr = key => {
 
 const updateContact = async () => {
   try {
+    await contactsFormRef.value?.flushPendingAttr?.();
     const { customAttributes, ...basicContactData } = contactData.value;
     await store.dispatch('contacts/update', {
       ...basicContactData,

--- a/app/javascript/dashboard/components-next/filter/contactProvider.js
+++ b/app/javascript/dashboard/components-next/filter/contactProvider.js
@@ -141,6 +141,16 @@ export function useContactFilterContext() {
       attributeModel: 'standard',
     },
     {
+      attributeKey: 'company_name',
+      value: 'company_name',
+      attributeName: t('CONTACTS_LAYOUT.FILTER.COMPANY'),
+      label: t('CONTACTS_LAYOUT.FILTER.COMPANY'),
+      inputType: 'plainText',
+      dataType: 'text',
+      filterOperators: containmentOperators.value,
+      attributeModel: 'additional',
+    },
+    {
       attributeKey: 'created_at',
       value: 'created_at',
       attributeName: t('CONTACTS_LAYOUT.FILTER.CREATED_AT'),

--- a/app/javascript/dashboard/components/table/Table.vue
+++ b/app/javascript/dashboard/components/table/Table.vue
@@ -40,7 +40,7 @@ const headerClass = computed(() =>
           :style="{
             width: `${header.getSize()}px`,
           }"
-          class="text-left py-3 px-5 font-medium text-sm text-n-slate-12"
+          class="text-left py-3 px-5 font-medium text-sm text-n-slate-12 whitespace-nowrap"
           :class="headerClass"
           @click="header.column.getCanSort() && header.column.toggleSorting()"
         >

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -477,6 +477,7 @@
         "VALUE_WITH_KEY": "Enter your '{key}'",
         "SEARCH_PLACEHOLDER": "Search or type a new name...",
         "CREATE_NEW": "Add \"{key}\"",
+        "PENDING_HINT": "Click + to add, or save directly",
         "DATA_TYPES": {
           "TEXT": "Text",
           "NUMBER": "Number",

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -474,7 +474,14 @@
         "DELETE_ALL": "All contacts",
         "NO_AVAILABLE_KEYS": "All information already added",
         "NEW_KEY_PLACEHOLDER": "New information name...",
-        "VALUE_WITH_KEY": "Enter your '{key}'"
+        "VALUE_WITH_KEY": "Enter your '{key}'",
+        "SEARCH_PLACEHOLDER": "Search or type a new name...",
+        "CREATE_NEW": "Add \"{key}\"",
+        "DATA_TYPES": {
+          "TEXT": "Text",
+          "NUMBER": "Number",
+          "DATE": "Date"
+        }
       }
     },
     "DETAILS": {

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -467,13 +467,13 @@
         }
       },
       "CUSTOM_ATTRIBUTES": {
-        "TITLE": "Custom Attributes",
-        "KEY_PLACEHOLDER": "Attribute name",
+        "TITLE": "Additional Information",
+        "KEY_PLACEHOLDER": "Information name",
         "VALUE_PLACEHOLDER": "Value",
         "DELETE_CONTACT": "This contact only",
         "DELETE_ALL": "All contacts",
-        "NO_AVAILABLE_KEYS": "All attributes already added",
-        "NEW_KEY_PLACEHOLDER": "New attribute name...",
+        "NO_AVAILABLE_KEYS": "All information already added",
+        "NEW_KEY_PLACEHOLDER": "New information name...",
         "VALUE_WITH_KEY": "Enter your '{key}'"
       }
     },

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -412,6 +412,9 @@
     "CARD": {
       "OF": "of",
       "VIEW_DETAILS": "View details",
+      "NEW_CONTACT_FORM": {
+        "TITLE": "Add new contact"
+      },
       "EDIT_DETAILS_FORM": {
         "TITLE": "Edit contact details",
         "FORM": {
@@ -448,6 +451,7 @@
       },
       "SOCIAL_MEDIA": {
         "TITLE": "Edit social links",
+        "TITLE_NEW": "Add social links",
         "FORM": {
           "FACEBOOK": {
             "PLACEHOLDER": "Add Facebook"

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -476,6 +476,11 @@
         "VALUE_PLACEHOLDER": "Value",
         "DELETE_CONTACT": "This contact only",
         "DELETE_ALL": "All contacts",
+        "DELETE_ALL_CONFIRM": {
+          "TITLE": "Delete attribute from all contacts?",
+          "DESCRIPTION": "The attribute '{key}' will be permanently deleted from all contacts. This action cannot be undone.",
+          "CONFIRM": "Yes, Delete Permanently"
+        },
         "NO_AVAILABLE_KEYS": "All information already added",
         "NEW_KEY_PLACEHOLDER": "New information name...",
         "VALUE_WITH_KEY": "Enter your '{key}'",

--- a/app/javascript/dashboard/i18n/locale/id/contact.json
+++ b/app/javascript/dashboard/i18n/locale/id/contact.json
@@ -383,6 +383,7 @@
       "IDENTIFIER": "Pengenal",
       "COUNTRY": "Negara",
       "CITY": "Kota",
+      "COMPANY": "Perusahaan",
       "CREATED_AT": "Dibuat pada",
       "LAST_ACTIVITY": "Aktivitas terakhir",
       "REFERER_LINK": "Tautan Rujukan",

--- a/app/javascript/dashboard/i18n/locale/id/contact.json
+++ b/app/javascript/dashboard/i18n/locale/id/contact.json
@@ -39,10 +39,10 @@
     },
     "MERGE_CONTACT": "Gabungkan Kontak",
     "CONTACT_ACTIONS": "Tindakan Kontak",
-    "MUTE_CONTACT": "Block Contact",
-    "UNMUTE_CONTACT": "Unblock Contact",
-    "MUTED_SUCCESS": "This contact is blocked successfully. You will not be notified of any future conversations.",
-    "UNMUTED_SUCCESS": "This contact is unblocked successfully.",
+    "MUTE_CONTACT": "Blokir Kontak",
+    "UNMUTE_CONTACT": "Buka Blokir Kontak",
+    "MUTED_SUCCESS": "Kontak ini berhasil diblokir. Anda tidak akan diberitahu tentang percakapan mendatang.",
+    "UNMUTED_SUCCESS": "Kontak ini berhasil dibuka blokirnya.",
     "SEND_TRANSCRIPT": "Kirim Transkrip",
     "EDIT_LABEL": "Edit",
     "SIDEBAR_SECTIONS": {
@@ -173,8 +173,8 @@
         "ERROR": "Pesan tidak boleh kosong"
       },
       "ATTACHMENTS": {
-        "SELECT": "Choose files",
-        "HELP_TEXT": "Drag and drop files here or choose files to attach"
+        "SELECT": "Pilih berkas",
+        "HELP_TEXT": "Seret dan lepas berkas di sini atau pilih berkas untuk dilampirkan"
       },
       "SUBMIT": "Kirim Pesan",
       "CANCEL": "Batalkan",
@@ -253,7 +253,7 @@
   },
   "MERGE_CONTACTS": {
     "TITLE": "Gabungkan Kontak",
-    "DESCRIPTION": "Merge contacts to combine two profiles into one, including all attributes and conversations. In case of conflict, the Primary contact’ s attributes will take precedence.",
+    "DESCRIPTION": "Gabungkan kontak untuk menyatukan dua profil menjadi satu, termasuk semua atribut dan percakapan. Jika ada konflik, atribut kontak Utama akan diprioritaskan.",
     "PRIMARY": {
       "TITLE": "Kontak Utama",
       "HELP_LABEL": "Akan dihapus"
@@ -269,7 +269,7 @@
       "ATTRIBUTE_WARNING": "Detail kontak dari <strong>{primaryContactName}</strong> akan disalin ke <strong>{parentContactName}</strong>."
     },
     "SEARCH": {
-      "ERROR": "PESAN_KESALAHAN"
+      "ERROR": "Tidak dapat mencari kontak. Silakan coba lagi nanti."
     },
     "FORM": {
       "SUBMIT": "Gabungkan Kontak",
@@ -288,7 +288,7 @@
   "CONTACTS_LAYOUT": {
     "HEADER": {
       "TITLE": "Kontak",
-      "SEARCH_TITLE": "Search contacts",
+      "SEARCH_TITLE": "Cari kontak",
       "SEARCH_PLACEHOLDER": "Cari...",
       "MESSAGE_BUTTON": "Pesan",
       "SEND_MESSAGE": "Kirim Pesan",
@@ -304,7 +304,7 @@
           "EMAIL_ADDRESS_DUPLICATE": "Alamat email ini digunakan untuk kontak lain.",
           "PHONE_NUMBER_DUPLICATE": "Nomor ini sudah digunakan oleh kontak lain.",
           "SUCCESS_MESSAGE": "Kontak berhasil disimpan",
-          "ERROR_MESSAGE": "Unable to save contact. Please try again later."
+          "ERROR_MESSAGE": "Tidak dapat menyimpan kontak. Silakan coba lagi nanti."
         },
         "IMPORT_CONTACT": {
           "TITLE": "Impor kontak",
@@ -315,7 +315,7 @@
           "CHANGE": "Ubah",
           "CANCEL": "Batalkan",
           "IMPORT": "Impor",
-          "SUCCESS_MESSAGE": "You will be notified via email when the import is complete.",
+          "SUCCESS_MESSAGE": "Anda akan mendapat notifikasi melalui email ketika impor selesai.",
           "ERROR_MESSAGE": "Terjadi kesalahan, harap coba lagi",
           "GUIDE": {
             "TITLE": "Cara menyiapkan data",
@@ -327,9 +327,9 @@
         },
         "EXPORT_CONTACT": {
           "TITLE": "Ekspor kontak",
-          "DESCRIPTION": "Quickly export a csv file with comprehensive details of your contacts",
+          "DESCRIPTION": "Ekspor cepat file CSV dengan detail lengkap kontak Anda",
           "CONFIRM": "Ekspor",
-          "SUCCESS_MESSAGE": "Export is in progress, You will be notified via email when export file is ready to dowanlod.",
+          "SUCCESS_MESSAGE": "Ekspor sedang berjalan, Anda akan mendapat notifikasi melalui email ketika file siap diunduh.",
           "ERROR_MESSAGE": "Terjadi kesalahan, harap coba lagi"
         },
         "SORT_BY": {
@@ -357,18 +357,18 @@
             "TITLE": "Apakah Anda ingin menyimpan filter ini?",
             "CONFIRM": "Simpan filter",
             "LABEL": "Nama",
-            "PLACEHOLDER": "Enter the name of the filter",
-            "ERROR": "Enter a valid name",
-            "SUCCESS_MESSAGE": "Filter saved successfully",
-            "ERROR_MESSAGE": "Unable to save filter. Please try again later."
+            "PLACEHOLDER": "Masukkan nama filter",
+            "ERROR": "Masukkan nama yang valid",
+            "SUCCESS_MESSAGE": "Filter berhasil disimpan",
+            "ERROR_MESSAGE": "Tidak dapat menyimpan filter. Silakan coba lagi nanti."
           },
           "DELETE_SEGMENT": {
             "TITLE": "Konfirmasi Penghapusan",
-            "DESCRIPTION": "Are you sure you want to delete this filter?",
+            "DESCRIPTION": "Apakah Anda yakin ingin menghapus filter ini?",
             "CONFIRM": "Ya, Hapus",
-            "CANCEL": "No, Cancel",
-            "SUCCESS_MESSAGE": "Filter deleted successfully",
-            "ERROR_MESSAGE": "Unable to delete filter. Please try again later."
+            "CANCEL": "Tidak, Batalkan",
+            "SUCCESS_MESSAGE": "Filter berhasil dihapus",
+            "ERROR_MESSAGE": "Tidak dapat menghapus filter. Silakan coba lagi nanti."
           }
         }
       }
@@ -391,24 +391,24 @@
       "BLOCKED_TRUE": "Benar",
       "BLOCKED_FALSE": "Salah",
       "BUTTONS": {
-        "CLEAR_FILTERS": "Clear filters",
-        "UPDATE_SEGMENT": "Update segment",
+        "CLEAR_FILTERS": "Hapus filter",
+        "UPDATE_SEGMENT": "Perbarui segmen",
         "APPLY_FILTERS": "Terapkan filter",
         "ADD_FILTER": "Tambah filter"
       },
       "TITLE": "Filter kontak",
       "EDIT_SEGMENT": "Edit Segmen",
       "SEGMENT": {
-        "LABEL": "Segment name",
-        "INPUT_PLACEHOLDER": "Enter the name of the segment"
+        "LABEL": "Nama segmen",
+        "INPUT_PLACEHOLDER": "Masukkan nama segmen"
       },
       "ACTIVE_FILTERS": {
-        "MORE_FILTERS": "+ {count} more filters",
-        "CLEAR_FILTERS": "Clear filters"
+        "MORE_FILTERS": "+ {count} filter lainnya",
+        "CLEAR_FILTERS": "Hapus filter"
       }
     },
     "CARD": {
-      "OF": "of",
+      "OF": "dari",
       "VIEW_DETAILS": "Lihat Detail",
       "EDIT_DETAILS_FORM": {
         "TITLE": "Edit detail kontak",
@@ -417,14 +417,14 @@
             "PLACEHOLDER": "Masukkan nama depan"
           },
           "LAST_NAME": {
-            "PLACEHOLDER": "Enter the last name"
+            "PLACEHOLDER": "Masukkan nama belakang"
           },
           "EMAIL_ADDRESS": {
             "PLACEHOLDER": "Masukkan alamat email",
             "DUPLICATE": "Alamat email ini digunakan untuk kontak lain."
           },
           "PHONE_NUMBER": {
-            "PLACEHOLDER": "Enter the phone number",
+            "PLACEHOLDER": "Masukkan nomor telepon",
             "DUPLICATE": "Nomor ini sudah digunakan oleh kontak lain."
           },
           "CITY": {
@@ -441,26 +441,26 @@
           }
         },
         "UPDATE_BUTTON": "Perbarui kontak",
-        "SUCCESS_MESSAGE": "Contact updated successfully",
-        "ERROR_MESSAGE": "Unable to update contact. Please try again later."
+        "SUCCESS_MESSAGE": "Kontak berhasil diperbarui",
+        "ERROR_MESSAGE": "Tidak dapat memperbarui kontak. Silakan coba lagi nanti."
       },
       "SOCIAL_MEDIA": {
         "TITLE": "Ubah link media sosial",
         "FORM": {
           "FACEBOOK": {
-            "PLACEHOLDER": "Add Facebook"
+            "PLACEHOLDER": "Tambahkan Facebook"
           },
           "GITHUB": {
-            "PLACEHOLDER": "Add Github"
+            "PLACEHOLDER": "Tambahkan Github"
           },
           "INSTAGRAM": {
-            "PLACEHOLDER": "Add Instagram"
+            "PLACEHOLDER": "Tambahkan Instagram"
           },
           "LINKEDIN": {
-            "PLACEHOLDER": "Add LinkedIn"
+            "PLACEHOLDER": "Tambahkan LinkedIn"
           },
           "TWITTER": {
-            "PLACEHOLDER": "Add Twitter"
+            "PLACEHOLDER": "Tambahkan Twitter"
           }
         }
       },
@@ -506,17 +506,15 @@
       "ADD_CUSTOM_COLUMN": "Tambah Kolom Kustom",
       "COLUMN_KEY": "Tambah kunci atribut",
       "COLUMN_LABEL": "Label"
-    }
-  },
-  "DETAILS": {
+    },
     "DETAILS": {
       "CREATED_AT": "Dibuat {date}",
-      "LAST_ACTIVITY": "Last active {date}",
-      "DELETE_CONTACT_DESCRIPTION": "Permanently delete this contact. This action is irreversible",
+      "LAST_ACTIVITY": "Terakhir aktif {date}",
+      "DELETE_CONTACT_DESCRIPTION": "Hapus kontak ini secara permanen. Tindakan ini tidak dapat dibatalkan.",
       "DELETE_CONTACT": "Hapus kontak",
       "DELETE_DIALOG": {
         "TITLE": "Konfirmasi Penghapusan",
-        "DESCRIPTION": "Are you sure you want to delete this {contactName} contact?",
+        "DESCRIPTION": "Apakah Anda yakin ingin menghapus kontak {contactName} ini?",
         "CONFIRM": "Ya, Hapus",
         "API": {
           "SUCCESS_MESSAGE": "Kontak berhasil dihapus",
@@ -525,19 +523,19 @@
       },
       "AVATAR": {
         "UPLOAD": {
-          "ERROR_MESSAGE": "Could not upload avatar. Please try again later.",
-          "SUCCESS_MESSAGE": "Avatar uploaded successfully"
+          "ERROR_MESSAGE": "Gagal mengunggah avatar. Silakan coba lagi nanti.",
+          "SUCCESS_MESSAGE": "Avatar berhasil diunggah"
         },
         "DELETE": {
           "SUCCESS_MESSAGE": "Avatar berhasil dihapus",
-          "ERROR_MESSAGE": "Could not delete avatar. Please try again later."
+          "ERROR_MESSAGE": "Gagal menghapus avatar. Silakan coba lagi nanti."
         }
       }
     },
     "SIDEBAR": {
       "TABS": {
         "ATTRIBUTES": "Atribut",
-        "HISTORY": "History",
+        "HISTORY": "Riwayat",
         "NOTES": "Catatan",
         "MERGE": "Gabungkan"
       },
@@ -545,8 +543,8 @@
         "EMPTY_STATE": "Tidak ada percakapan sebelumnya yang terkait dengan kontak ini"
       },
       "ATTRIBUTES": {
-        "SEARCH_PLACEHOLDER": "Search for attributes",
-        "UNUSED_ATTRIBUTES": "{count} Used attribute | {count} Unused attributes",
+        "SEARCH_PLACEHOLDER": "Cari atribut",
+        "UNUSED_ATTRIBUTES": "{count} Atribut terpakai | {count} Atribut tidak terpakai",
         "EMPTY_STATE": "Tidak ada atribut tambahan untuk kontak di akun ini. Silakan buat atribut baru melalui menu pengaturan.",
         "YES": "Ya",
         "NO": "Tidak",
@@ -555,11 +553,11 @@
           "INPUT": "Masukkan data"
         },
         "VALIDATIONS": {
-          "INVALID_NUMBER": "Invalid number",
+          "INVALID_NUMBER": "Nomor tidak valid",
           "REQUIRED": "Nilai yang valid diperlukan",
-          "INVALID_INPUT": "Invalid input",
+          "INVALID_INPUT": "Masukan tidak valid",
           "INVALID_URL": "URL tidak valid",
-          "INVALID_DATE": "Invalid date"
+          "INVALID_DATE": "Tanggal tidak valid"
         },
         "NO_ATTRIBUTES": "Tidak ditemukan atribut",
         "API": {
@@ -574,13 +572,13 @@
         "DESCRIPTION": "Satukan dua profil menjadi satu, dengan semua atribut dan percakapan. Atribut kontak utama akan diprioritaskan jika ada konflik.",
         "PRIMARY": "Kontak Utama",
         "PRIMARY_HELP_LABEL": "Akan disimpan",
-        "PRIMARY_REQUIRED_ERROR": "Please select a contact to merge with before proceeding",
+        "PRIMARY_REQUIRED_ERROR": "Pilih kontak yang akan digabungkan sebelum melanjutkan",
         "PARENT": "Akan digabungkan",
         "PARENT_HELP_LABEL": "Akan dihapus",
         "EMPTY_STATE": "Tidak ada kontak yang ditemukan",
         "PLACEHOLDER": "Cari kontak utama yang terdaftar" ,
         "SEARCH_PLACEHOLDER": "Cari kontak",
-        "SEARCH_ERROR_MESSAGE": "Could not search for contacts. Please try again later.",
+        "SEARCH_ERROR_MESSAGE": "Tidak dapat mencari kontak. Silakan coba lagi nanti.",
         "SUCCESS_MESSAGE": "Kontak berhasil digabungkan",
         "ERROR_MESSAGE": "Tidak dapat menggabungkan kontak, coba lagi!",
         "IS_SEARCHING": "Sedang mencari...",
@@ -593,7 +591,7 @@
         "PLACEHOLDER": "Tambahkan Catatan",
         "WROTE": "menulis",
         "YOU": "Anda",
-        "SAVE": "Save note",
+        "SAVE": "Simpan catatan",
         "EMPTY_STATE": "Belum ada catatan untuk kontak ini. Anda bisa menambahkan catatan dengan mengetik di kotak di atas."
       }
     },
@@ -611,13 +609,13 @@
     },
     "FORM": {
       "GO_TO_CONVERSATION": "Lihat",
-      "SUCCESS_MESSAGE": "The message was sent successfully!",
-      "ERROR_MESSAGE": "An error occurred while creating the conversation. Please try again later.",
-      "NO_INBOX_ALERT": "There are no available inboxes to start a conversation with this contact.",
+      "SUCCESS_MESSAGE": "Pesan berhasil terkirim!",
+      "ERROR_MESSAGE": "Terjadi kesalahan saat membuat percakapan. Silakan coba lagi nanti.",
+      "NO_INBOX_ALERT": "Tidak ada kotak masuk yang tersedia untuk memulai percakapan dengan kontak ini.",
       "CONTACT_SELECTOR": {
         "LABEL": "Kepada:",
         "TAG_INPUT_PLACEHOLDER": "Cari kontak berdasarkan nama, email, atau nomor telepon",
-        "CONTACT_CREATING": "Creating contact..."
+        "CONTACT_CREATING": "Membuat kontak..."
       },
       "INBOX_SELECTOR": {
         "LABEL": "Melalui:",
@@ -625,20 +623,20 @@
       },
       "EMAIL_OPTIONS": {
         "SUBJECT_LABEL": "Masukkan subjek :",
-        "SUBJECT_PLACEHOLDER": "Enter your email subject here",
+        "SUBJECT_PLACEHOLDER": "Masukkan subjek email di sini",
         "CC_LABEL": "Cc:",
-        "CC_PLACEHOLDER": "Search for a contact with their email address",
+        "CC_PLACEHOLDER": "Cari kontak berdasarkan alamat email",
         "BCC_LABEL": "Bcc:",
-        "BCC_PLACEHOLDER": "Search for a contact with their email address",
+        "BCC_PLACEHOLDER": "Cari kontak berdasarkan alamat email",
         "BCC_BUTTON": "Bcc"
       },
       "MESSAGE_EDITOR": {
         "PLACEHOLDER": "Tulis pesan Anda di sini..."
       },
       "WHATSAPP_OPTIONS": {
-        "LABEL": "Select template",
-        "SEARCH_PLACEHOLDER": "Search templates",
-        "EMPTY_STATE": "No templates found",
+        "LABEL": "Pilih template",
+        "SEARCH_PLACEHOLDER": "Cari template",
+        "EMPTY_STATE": "Tidak ada template yang ditemukan",
         "TEMPLATE_PARSER": {
           "TEMPLATE_NAME": "WhatsApp template: {templateName}",
           "VARIABLES": "Variabel",

--- a/app/javascript/dashboard/i18n/locale/id/contact.json
+++ b/app/javascript/dashboard/i18n/locale/id/contact.json
@@ -410,6 +410,9 @@
     "CARD": {
       "OF": "dari",
       "VIEW_DETAILS": "Lihat Detail",
+      "NEW_CONTACT_FORM": {
+        "TITLE": "Tambah kontak baru"
+      },
       "EDIT_DETAILS_FORM": {
         "TITLE": "Edit detail kontak",
         "FORM": {
@@ -446,6 +449,7 @@
       },
       "SOCIAL_MEDIA": {
         "TITLE": "Ubah link media sosial",
+        "TITLE_NEW": "Tambahkan link media sosial",
         "FORM": {
           "FACEBOOK": {
             "PLACEHOLDER": "Tambahkan Facebook"

--- a/app/javascript/dashboard/i18n/locale/id/contact.json
+++ b/app/javascript/dashboard/i18n/locale/id/contact.json
@@ -474,6 +474,11 @@
         "VALUE_PLACEHOLDER": "Masukkan nilai",
         "DELETE_CONTACT": "Kontak ini saja",
         "DELETE_ALL": "Semua kontak",
+        "DELETE_ALL_CONFIRM": {
+          "TITLE": "Hapus atribut dari semua kontak?",
+          "DESCRIPTION": "Atribut '{key}' akan dihapus permanen dari seluruh kontak. Tindakan ini tidak dapat dibatalkan.",
+          "CONFIRM": "Ya, Hapus Permanen"
+        },
         "NO_AVAILABLE_KEYS": "Semua informasi sudah ditambahkan",
         "NEW_KEY_PLACEHOLDER": "Nama informasi baru...",
         "VALUE_WITH_KEY": "Masukkan '{key}' Anda",

--- a/app/javascript/dashboard/i18n/locale/id/contact.json
+++ b/app/javascript/dashboard/i18n/locale/id/contact.json
@@ -475,6 +475,7 @@
         "VALUE_WITH_KEY": "Masukkan '{key}' Anda",
         "SEARCH_PLACEHOLDER": "Cari atau tulis nama baru...",
         "CREATE_NEW": "Tambah \"{key}\"",
+        "PENDING_HINT": "Klik + untuk menambah, atau langsung simpan",
         "DATA_TYPES": {
           "TEXT": "Teks",
           "NUMBER": "Angka",

--- a/app/javascript/dashboard/i18n/locale/id/contact.json
+++ b/app/javascript/dashboard/i18n/locale/id/contact.json
@@ -464,13 +464,13 @@
         }
       },
       "CUSTOM_ATTRIBUTES": {
-        "TITLE": "Atribut Kustom",
-        "KEY_PLACEHOLDER": "Nama atribut",
+        "TITLE": "Informasi Tambahan",
+        "KEY_PLACEHOLDER": "Nama informasi",
         "VALUE_PLACEHOLDER": "Masukkan nilai",
         "DELETE_CONTACT": "Kontak ini saja",
         "DELETE_ALL": "Semua kontak",
-        "NO_AVAILABLE_KEYS": "Semua atribut sudah ditambahkan",
-        "NEW_KEY_PLACEHOLDER": "Nama atribut baru...",
+        "NO_AVAILABLE_KEYS": "Semua informasi sudah ditambahkan",
+        "NEW_KEY_PLACEHOLDER": "Nama informasi baru...",
         "VALUE_WITH_KEY": "Masukkan '{key}' Anda"
       }
     },

--- a/app/javascript/dashboard/i18n/locale/id/contact.json
+++ b/app/javascript/dashboard/i18n/locale/id/contact.json
@@ -471,7 +471,14 @@
         "DELETE_ALL": "Semua kontak",
         "NO_AVAILABLE_KEYS": "Semua informasi sudah ditambahkan",
         "NEW_KEY_PLACEHOLDER": "Nama informasi baru...",
-        "VALUE_WITH_KEY": "Masukkan '{key}' Anda"
+        "VALUE_WITH_KEY": "Masukkan '{key}' Anda",
+        "SEARCH_PLACEHOLDER": "Cari atau tulis nama baru...",
+        "CREATE_NEW": "Tambah \"{key}\"",
+        "DATA_TYPES": {
+          "TEXT": "Teks",
+          "NUMBER": "Angka",
+          "DATE": "Tanggal"
+        }
       }
     },
     "TABLE": {

--- a/app/javascript/dashboard/routes/dashboard/contacts/pages/ContactsIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/pages/ContactsIndex.vue
@@ -78,11 +78,14 @@ const visibleColumns = computed(
   () => uiSettings.value?.contacts_visible_columns || [...ALWAYS_VISIBLE_KEYS]
 );
 
+const formatAttrLabel = key =>
+  key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+
 // Custom attribute column definitions to pass to the table
 const allCustomColumnDefs = computed(() =>
   (contactAttributeKeys.value || []).map(r => ({
     key: r.key,
-    label: r.key,
+    label: formatAttrLabel(r.key),
   }))
 );
 
@@ -404,7 +407,7 @@ onMounted(async () => {
                 :checked="isChecked(r.key)"
                 @change="toggleColumn(r.key)"
               />
-              <span class="text-sm text-n-slate-12 truncate">{{ r.key }}</span>
+              <span class="text-sm text-n-slate-12 truncate">{{ formatAttrLabel(r.key) }}</span>
             </label>
           </template>
         </div>

--- a/app/javascript/shared/helpers/timeHelper.js
+++ b/app/javascript/shared/helpers/timeHelper.js
@@ -4,6 +4,14 @@ import {
   fromUnixTime,
   formatDistanceToNow,
 } from 'date-fns';
+import { id as idLocale, enUS } from 'date-fns/locale';
+
+const getDateFnsLocale = () => {
+  const lang =
+    (typeof navigator !== 'undefined' && navigator.language?.split('-')[0]) ||
+    'en';
+  return lang === 'id' ? idLocale : enUS;
+};
 
 /**
  * Formats a Unix timestamp into a human-readable time format.
@@ -39,7 +47,7 @@ export const messageTimestamp = (time, dateFormat = 'MMM d, yyyy') => {
  */
 export const dynamicTime = time => {
   const unixTime = fromUnixTime(time);
-  return formatDistanceToNow(unixTime, { addSuffix: true });
+  return formatDistanceToNow(unixTime, { addSuffix: true, locale: getDateFnsLocale() });
 };
 
 /**

--- a/lib/filters/filter_keys.yml
+++ b/lib/filters/filter_keys.yml
@@ -173,7 +173,7 @@ contacts:
       - "not_equal_to"
       - "contains"
       - "does_not_contain"
-  company:
+  company_name:
     attribute_type: "additional_attributes"
     data_type: "text_case_insensitive"
     filter_operators:


### PR DESCRIPTION
# Pull Request Template

## Description

This PR continues and finalizes the contacts UI revamp, building on the previous merge into `release/staging`. Key improvements include:

- **Contacts table**: added email sub-text, company icon, flag for location, date locale based on `navigator.language`, and fixed header wrapping
- **Column settings**: custom attribute keys now display as Title Case instead of raw snake_case
- **Collapsible sidebar**: added toggle button (default hidden); fixed content offset when sidebar is collapsed
- **Custom attributes form**:
  - Renamed section label from "Atribut Kustom" to "Informasi Tambahan" for friendlier wording
  - Merged "add new attribute" form into the same card as existing attributes (unified UX)
  - Fixed attribute key input — now uses a searchable combobox with creatable option and localized data type labels
  - Added inline confirmation panel for global delete ("Semua kontak") with explicit irreversibility warning
- **Company name filter**: added `company_name` to contact filter options
- **Error handling**: replaced toast notifications (hidden behind native `<dialog>` top layer) with inline error messages in create/edit contact dialogs
- **Form titles**: differentiated "Tambah kontak baru" vs "Edit detail kontak" based on form mode
- **i18n (id locale)**: fixed structural JSON bug, translated all remaining English strings to Indonesian, localized `formatDistanceToNow` using `date-fns/locale`

Fixes ongoing issues from `fix/revamp-contact` branch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually tested contacts table: column visibility, sorting, custom attribute columns, edit modal
- Tested create contact dialog: duplicate email/phone error shown inline
- Tested custom attribute delete: "Kontak ini saja" removes from local state, "Semua kontak" shows inline warning panel before executing
- Tested sidebar toggle: persists across page reload via localStorage, content recenters when collapsed
- Tested company name filter in contact filters
- Verified Indonesian locale: relative timestamps, date formatting, all UI strings

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules