### PR TITLE
fix: implement soft delete for platform channels

### DIFF
--- a/app/controllers/api/v1/accounts/assignable_agents_controller.rb
+++ b/app/controllers/api/v1/accounts/assignable_agents_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::Accounts::AssignableAgentsController < Api::V1::Accounts::BaseCon
   private
 
   def fetch_inboxes
-    @inboxes = Current.account.inboxes.find(permitted_params[:inbox_ids])
+    @inboxes = Current.account.inboxes.unscope(where: :deleted_at).find(permitted_params[:inbox_ids])
   end
 
   def permitted_params

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -64,7 +64,10 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController #
   end
 
   def destroy
-    ::DeleteObjectJob.perform_later(@inbox, Current.user, request.ip) if @inbox.present?
+    if @inbox.present?
+      @inbox.soft_delete!
+    end
+
     render status: :ok, json: { message: I18n.t('messages.inbox_deletetion_response') }
   end
 

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -70,10 +70,12 @@ class ConversationFinder
   end
 
   def set_inboxes
+    inboxes_scope = @current_user.assigned_inboxes.unscope(where: :deleted_at)
+
     @inbox_ids = if params[:inbox_id]
-                   @current_user.assigned_inboxes.where(id: params[:inbox_id])
+                   inboxes_scope.where(id: params[:inbox_id])
                  else
-                   @current_user.assigned_inboxes.pluck(:id)
+                   inboxes_scope.pluck(:id)
                  end
   end
 

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationHeader.vue
@@ -107,6 +107,9 @@ export default {
       const { inbox_id: inboxId } = this.chat;
       return this.$store.getters['inboxes/getInbox'](inboxId);
     },
+    isInboxDeleted() {
+      return this.inbox && this.inbox.name === 'Platform Sebelumnya';
+    },
     hasMultipleInboxes() {
       return this.$store.getters['inboxes/getInboxes'].length > 1;
     },
@@ -200,7 +203,7 @@ export default {
           v-if="isLinearIntegrationEnabled && isLinearFeatureEnabled"
           :conversation-id="currentChat.id"
         />
-        <MoreActions :conversation-id="currentChat.id" />
+        <MoreActions v-if="!isInboxDeleted" :conversation-id="currentChat.id" />
       </div>
     </div>
   </div>

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -201,6 +201,11 @@ export default {
     inbox() {
       return this.$store.getters['inboxes/getInbox'](this.inboxId);
     },
+    isInboxDeleted() {
+      const inboxId = this.currentChat.inbox_id;
+      const inbox = this.$store.getters['inboxes/getInbox'](inboxId);
+      return inbox && inbox.name === 'Platform Sebelumnya';
+    },
     messagePlaceHolder() {
       const isSubscriptionActive = this.isSubscriptionActive
       const isPrivate = this.isPrivate
@@ -1120,7 +1125,11 @@ export default {
     :action-button-label="$t('CONVERSATION.ASSIGN_TO_ME')"
     @primary-action="onClickSelfAssign"
   />
-  <div ref="replyEditor" class="reply-box" :class="replyBoxClass">
+  <div v-if="isInboxDeleted" class="p-4 mx-4 mb-4 text-center rounded-md text-slate-500 bg-slate-50 dark:text-slate-400 dark:bg-slate-800 border border-slate-100 dark:border-slate-700/50">
+    <fluent-icon icon="info" class="mr-2 align-middle" />
+    <span>Anda tidak dapat membalas percakapan ini karena platform telah dihapus.</span>
+  </div>
+  <div v-else ref="replyEditor" class="reply-box" :class="replyBoxClass">
     <ReplyTopPanel
       :mode="replyType"
       :is-message-length-reaching-threshold="isMessageLengthReachingThreshold"

--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -92,7 +92,13 @@ export const getters = {
     const [inbox] = $state.records.filter(
       record => record.id === Number(inboxId)
     );
-    return inbox || {};
+    return inbox || {
+      id: Number(inboxId),
+      name: 'Platform Sebelumnya',
+      channel_type: 'Channel::Unknown',
+      avatar_url: '',
+      phone_number: ''
+    };
   },
   getInboxById: $state => inboxId => {
     const [inbox] = $state.records.filter(

--- a/app/jobs/cleanup_device_job.rb
+++ b/app/jobs/cleanup_device_job.rb
@@ -1,0 +1,18 @@
+class CleanupDeviceJob < ApplicationJob
+  queue_as :low
+
+  def perform(channel_id)
+    waha_service = Waha::WahaService.instance
+    waha_service.delete_device(device_id: channel_id)
+
+    channel = Channel::WhatsappUnofficial.find_by(id: channel_id)
+    
+    if channel && !channel.phone_number.to_s.include?('_deleted_')
+      new_phone_number = "#{channel.phone_number}_deleted_#{Time.current.to_i}"
+      channel.update_columns(phone_number: new_phone_number)
+    end
+
+  rescue StandardError => e
+    Rails.logger.error "Gagal memproses cleanup untuk channel #{channel_id}: #{e.message}"
+  end
+end

--- a/app/models/agent_bot.rb
+++ b/app/models/agent_bot.rb
@@ -22,7 +22,7 @@ class AgentBot < ApplicationRecord
   include Avatarable
 
   has_many :agent_bot_inboxes, dependent: :destroy_async
-  has_many :inboxes, through: :agent_bot_inboxes
+  has_many :inboxes, -> { unscope(where: :deleted_at) }, through: :agent_bot_inboxes
   has_many :messages, as: :sender, dependent: :nullify
   belongs_to :account, optional: true
   enum bot_type: { webhook: 0, csml: 1 }

--- a/app/models/agent_bot_inbox.rb
+++ b/app/models/agent_bot_inbox.rb
@@ -20,7 +20,7 @@ class AgentBotInbox < ApplicationRecord
   validates :ai_agent_id, presence: true
   before_validation :ensure_account_id
 
-  belongs_to :inbox
+  belongs_to :inbox, -> { unscope(where: :deleted_at) }
   belongs_to :ai_agent
   belongs_to :account
 

--- a/app/models/agent_notification_setting.rb
+++ b/app/models/agent_notification_setting.rb
@@ -32,7 +32,7 @@
 class AgentNotificationSetting < ApplicationRecord
   belongs_to :account
   belongs_to :ai_agent
-  belongs_to :inbox
+  belongs_to :inbox, -> { unscope(where: :deleted_at) }
 
   validates :message_type, presence: true, inclusion: { in: %w[personal group] }
   validates :receiver_address, presence: true

--- a/app/models/contact_inbox.rb
+++ b/app/models/contact_inbox.rb
@@ -29,7 +29,7 @@ class ContactInbox < ApplicationRecord
   validate :valid_source_id_format?
 
   belongs_to :contact
-  belongs_to :inbox
+  belongs_to :inbox, -> { unscope(where: :deleted_at) }
 
   has_many :conversations, dependent: :destroy_async
 

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -73,6 +73,7 @@ class Conversation < ApplicationRecord
   validates :custom_attributes, jsonb_attributes_length: true
   validates :uuid, uniqueness: true
   validate :validate_referer_url
+  validate :prevent_reopen_if_inbox_deleted, on: :update, if: :status_changed?
 
   enum status: { open: 0, resolved: 1, pending: 2, snoozed: 3 }
   enum priority: { low: 0, medium: 1, high: 2, urgent: 3 }
@@ -326,6 +327,12 @@ class Conversation < ApplicationRecord
   # creating db triggers
   trigger.before(:insert).for_each(:row) do
     "NEW.display_id := nextval('conv_dpid_seq_' || NEW.account_id);"
+  end
+
+  def prevent_reopen_if_inbox_deleted
+    if !resolved? && inbox.present? && inbox.deleted_at.present?
+      errors.add(:base, 'Percakapan tidak bisa dibuka kembali karena platform telah dihapus.')
+    end
   end
 end
 

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -101,7 +101,7 @@ class Conversation < ApplicationRecord
   }
 
   belongs_to :account
-  belongs_to :inbox
+  belongs_to :inbox, -> { unscope(where: :deleted_at) }
   belongs_to :assignee, class_name: 'User', optional: true, inverse_of: :assigned_conversations
   belongs_to :contact
   belongs_to :contact_inbox

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -11,6 +11,7 @@
 #  channel_status                :boolean          default(TRUE)
 #  channel_type                  :string
 #  csat_survey_enabled           :boolean          default(FALSE)
+#  deleted_at                    :datetime
 #  email_address                 :string
 #  enable_auto_assignment        :boolean          default(TRUE)
 #  enable_email_collect          :boolean          default(TRUE)
@@ -33,6 +34,7 @@
 #  index_inboxes_on_account_id                   (account_id)
 #  index_inboxes_on_channel_id_and_channel_type  (channel_id,channel_type)
 #  index_inboxes_on_channel_status               (channel_status)
+#  index_inboxes_on_deleted_at                   (deleted_at)
 #  index_inboxes_on_portal_id                    (portal_id)
 #
 # Foreign Keys
@@ -56,19 +58,21 @@ class Inbox < ApplicationRecord
   validates :greeting_message, length: { maximum: Limits::GREETING_MESSAGE_MAX_LENGTH }
   validate :ensure_valid_max_assignment_limit
 
+  default_scope { where(deleted_at: nil) }
+
   belongs_to :account
   belongs_to :portal, optional: true
 
   belongs_to :channel, polymorphic: true, dependent: :destroy
 
   has_many :campaigns, dependent: :destroy_async
-  has_many :contact_inboxes, dependent: :destroy_async
+  has_many :contact_inboxes
   has_many :contacts, through: :contact_inboxes
 
   has_many :inbox_members, dependent: :destroy_async
   has_many :members, through: :inbox_members, source: :user
-  has_many :conversations, dependent: :destroy_async
-  has_many :messages, dependent: :destroy_async
+  has_many :conversations
+  has_many :messages
   has_one :agent_bot_inbox, -> { order(created_at: :asc) }, class_name: 'AgentBotInbox'
   has_many :agent_bot_inboxes, class_name: 'AgentBotInbox', dependent: :destroy_async
 
@@ -81,8 +85,6 @@ class Inbox < ApplicationRecord
   has_many :hooks, dependent: :destroy_async, class_name: 'Integrations::Hook'
 
   enum sender_name_type: { friendly: 0, professional: 1 }
-
-  after_destroy :delete_round_robin_agents
 
   after_create_commit :dispatch_create_event
   after_update_commit :dispatch_update_event
@@ -172,6 +174,15 @@ class Inbox < ApplicationRecord
 
   def member_ids_with_assignment_capacity
     members.ids
+  end
+
+  def soft_delete!
+    update(deleted_at: Time.current)
+    delete_round_robin_agents
+  end
+
+  def restore!
+    update(deleted_at: nil)
   end
 
   private

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -179,6 +179,8 @@ class Inbox < ApplicationRecord
   def soft_delete!
     update(deleted_at: Time.current)
     delete_round_robin_agents
+    cleanup_device
+    resolve_all_conversations!
   end
 
   def restore!
@@ -209,6 +211,16 @@ class Inbox < ApplicationRecord
 
   def check_channel_type?
     ['Channel::Email', 'Channel::Api', 'Channel::WebWidget'].include?(channel_type)
+  end
+
+  def cleanup_device
+    if whatsapp_unofficial?
+      ::CleanupDeviceJob.perform_later(channel_id)
+    end
+  end
+
+  def resolve_all_conversations!
+    conversations.where.not(status: :resolved).update_all(status: :resolved)
   end
 end
 

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -220,7 +220,7 @@ class Inbox < ApplicationRecord
   end
 
   def resolve_all_conversations!
-    conversations.where.not(status: :resolved).update_all(status: :resolved)
+    conversations.where.not(status: :resolved).update_all(status: :resolved, assignee_id: nil)
   end
 end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -119,7 +119,7 @@ class Message < ApplicationRecord
   default_scope { order(created_at: :asc) }
 
   belongs_to :account
-  belongs_to :inbox
+  belongs_to :inbox, -> { unscope(where: :deleted_at) }
   belongs_to :conversation, touch: true
   belongs_to :sender, polymorphic: true, optional: true
 

--- a/app/policies/inbox_policy.rb
+++ b/app/policies/inbox_policy.rb
@@ -23,7 +23,7 @@ class InboxPolicy < ApplicationPolicy
     # FIXME: for agent bots, lets bring this validation to policies as well in future
     return true if @user.is_a?(AgentBot)
 
-    Current.user.assigned_inboxes.include? record
+    Current.user.assigned_inboxes.unscope(where: :deleted_at).include? record
   end
 
   def assignable_agents?

--- a/db/migrate/20260525133236_add_deleted_at_to_inboxes.rb
+++ b/db/migrate/20260525133236_add_deleted_at_to_inboxes.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToInboxes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :inboxes, :deleted_at, :datetime
+    add_index :inboxes, :deleted_at
+  end
+end


### PR DESCRIPTION
- Add deleted_at datetime column to inboxes table via migration
- Add default_scope to filter out soft-deleted inboxes
- Introduce soft_delete! and restore! methods in Inbox model
- Modify inboxes_controller#destroy to use soft_delete! instead of hard delete (DeleteObjectJob)
- Retain dependent conversations and messages for historical data