### PR TITLE
fix: skip AI request for non-text and non-image messages

### DIFF
--- a/app/services/captain/copilot/chat_service.rb
+++ b/app/services/captain/copilot/chat_service.rb
@@ -2,6 +2,8 @@ class Captain::Copilot::ChatService
   include SwitchLocale
   include ResponseFormatChatHelper
 
+  AI_SUPPORTED_ATTACHMENT_TYPES = %w[image].freeze
+
   def initialize(message)
     @message = message
     @context = Captain::Copilot::MessageContext.new(message)
@@ -18,12 +20,25 @@ class Captain::Copilot::ChatService
       return unless @context.agent_bot_inbox
       return unless @context.ai_agent
       return unless @context.bot_available?
+      return unless meaningful_for_ai?
 
       send_messages
     end
   end
 
   private
+
+  def meaningful_for_ai?
+    return true if @message.content.present?
+    return true if @message.attachments.any? { |att| AI_SUPPORTED_ATTACHMENT_TYPES.include?(att.file_type) }
+
+    Rails.logger.info(
+      "[ChatService] Skipping AI request — no text or image content | " \
+      "message_id=#{@message.id} | " \
+      "attachment_types=#{@message.attachments.map(&:file_type)}"
+    )
+    false
+  end
 
   def pre_check_failure_reason
     return I18n.t('subscriptions.limit_reached') unless @context.subscription

--- a/app/services/whatsapp_unofficial/incoming_message_service.rb
+++ b/app/services/whatsapp_unofficial/incoming_message_service.rb
@@ -147,7 +147,7 @@ class WhatsappUnofficial::IncomingMessageService
   end
 
   def media_path
-    return file[:media_path] || file['media_path'] if file.is_a?(Hash)
+    return file[:media_path] || file['media_path'] || file[:path] || file['path'] if file.is_a?(Hash)
     return file if file.is_a?(String)
 
     nil


### PR DESCRIPTION
## Summary

- Sticker, audio, video, document, location, dan contact card dari WhatsApp selama ini dikirim ke LangGraph dengan `question=""` dan `attachments=[]`
- Tambah guard `meaningful_for_ai?` di `Captain::Copilot::ChatService` untuk skip message yang tidak ada text content dan tidak ada image attachment
- Supported types didefinisikan di constant `AI_SUPPORTED_ATTACHMENT_TYPES = %w[image].freeze` — mudah di-extend kalau nanti LangGraph support tipe lain

## Root cause

Payload stiker dari Gowa hanya berisi key `:sticker`, tidak ada `:body` atau `:image`, sehingga:
1. `message_content = ""` (kosong)
2. `message_params? = false` → tidak ada attachment yang di-attach
3. LangGraph menerima request dengan `question=""` + `attachments=[]` → `HumanMessage(content=[])` → error

## Test plan

- [x] Kirim stiker dari WhatsApp → tidak ada response dari bot, tidak ada error di log LangGraph
- [x] Kirim audio → tidak ada response dari bot
- [x] Kirim pesan teks biasa → bot tetap reply normal
- [x] Kirim gambar (dengan atau tanpa caption) → bot tetap reply normal