### PR TITLE
feat: increment ai usage on idle message generation

### DIFF
--- a/app/jobs/notify_idle_conversation_job.rb
+++ b/app/jobs/notify_idle_conversation_job.rb
@@ -47,6 +47,7 @@ class NotifyIdleConversationJob < ApplicationJob
     handle_orphaned_conversation(idle_conversation) && return if orphaned?(idle_conversation)
     return if (message = generate_message(idle_conversation)).nil?
 
+    increment_ai_usage(idle_conversation)
     create_message(message, conversation_attributes(idle_conversation))
     idle_conversation.mark_as_sent!
     idle_conversation.mark_as_conversation_resolved! if idle_conversation.completed?
@@ -95,6 +96,18 @@ class NotifyIdleConversationJob < ApplicationJob
       inbox_id: idle_conversation.inbox_id,
       conversation_id: idle_conversation.conversation_id
     }
+  end
+
+  def increment_ai_usage(idle_conversation)
+    subscription = Subscription.find_by(account_id: idle_conversation.account_id, status: 'active')
+    return unless subscription
+
+    usage = SubscriptionUsage.find_or_create_by(subscription_id: subscription.id)
+    return unless usage
+
+    usage.increment_ai_responses
+  rescue StandardError => e
+    Rails.logger.error "[NotifyIdleConversationJob] Failed to increment AI usage for idle_conversation #{idle_conversation.id}: #{e.message}"
   end
 
   def idle_conversations

--- a/app/jobs/notify_idle_conversation_job.rb
+++ b/app/jobs/notify_idle_conversation_job.rb
@@ -45,9 +45,18 @@ class NotifyIdleConversationJob < ApplicationJob
 
   def idle_conversation_processor(idle_conversation)
     handle_orphaned_conversation(idle_conversation) && return if orphaned?(idle_conversation)
+
+    usage = find_usage(idle_conversation.account_id)
+    if usage_limit_reached?(usage)
+      Rails.logger.warn "[NotifyIdleConversationJob] Subscription inactive for account #{idle_conversation.account_id} — marking idle_conversation #{idle_conversation.id} as completed"
+      idle_conversation.update!(status: :completed)
+      idle_conversation.mark_as_conversation_resolved!
+      return
+    end
+
     return if (message = generate_message(idle_conversation)).nil?
 
-    increment_ai_usage(idle_conversation)
+    usage.increment_ai_responses
     create_message(message, conversation_attributes(idle_conversation))
     idle_conversation.mark_as_sent!
     idle_conversation.mark_as_conversation_resolved! if idle_conversation.completed?
@@ -98,16 +107,25 @@ class NotifyIdleConversationJob < ApplicationJob
     }
   end
 
-  def increment_ai_usage(idle_conversation)
-    subscription = Subscription.find_by(account_id: idle_conversation.account_id, status: 'active')
-    return unless subscription
+  def find_usage(account_id)
+    subscription = Subscription.active.find_by(account_id: account_id)
+    return nil unless subscription
 
-    usage = SubscriptionUsage.find_or_create_by(subscription_id: subscription.id)
-    return unless usage
-
-    usage.increment_ai_responses
+    SubscriptionUsage.find_or_create_by(subscription_id: subscription.id)
   rescue StandardError => e
-    Rails.logger.error "[NotifyIdleConversationJob] Failed to increment AI usage for idle_conversation #{idle_conversation.id}: #{e.message}"
+    Rails.logger.error "[NotifyIdleConversationJob] Error finding usage for account #{account_id}: #{e.message}"
+    nil
+  end
+
+  def usage_limit_reached?(usage)
+    return true if usage.nil?
+
+    if usage.exceeded_limits?
+      Rails.logger.warn "[NotifyIdleConversationJob] Skipping idle message — usage limit reached (subscription_id=#{usage.subscription_id})"
+      return true
+    end
+
+    false
   end
 
   def idle_conversations


### PR DESCRIPTION
## Summary

Sebelumnya, `NotifyIdleConversationJob` tidak memiliki guard apapun terhadap status subscription — job akan terus memanggil Jangkau AI API dan mengirim idle message meski subscription expired atau usage limit tercapai.

PR ini menambahkan dua hal:
- **Guard subscription** — skip idle message jika subscription tidak aktif atau usage limit terlampaui
- **Increment `ai_responses_count`** — setiap kali AI berhasil generate idle message

## Konteks: `is_failure` di **ChatService yang baru saja ditambahkan di commit sebelum PR ini sudah menangani bug yang baru dilaporkan (subscription habis masih mengirim idle message)**, tapi masih perlu guard tambahan

`ChatService` baru saja mendapat `is_failure: true` yang mencegah `AddIdleConversationJob` dipanggil ketika subscription tidak aktif:

```ruby
# chat_service.rb
end_state_processing(response) unless response[:is_handover] || response[:is_failure]
```

Artinya, ketika customer mengirim pesan baru dan subscription expired, **IdleConversation baru tidak akan dibuat**. Namun ada beberapa kondisi edge case yang tetap bisa terjadi dan masih membutuhkan guard di sisi `NotifyIdleConversationJob`:

### Edge case yang masih perlu di-guard

**1. IdleConversation sudah ada sebelum subscription expired**
```
Customer kirim pesan → subscription aktif → AI reply
→ AddIdleConversationJob buat IdleConversation (step 0)
→ Subscription expired di titik ini
→ 5 menit kemudian: NotifyIdleConversationJob masih memproses
  record lama tersebut → idle message tetap terkirim 
```

**2. Subscription expired**
Guard kita menggunakan `Subscription.active` scope yang mengecek **keduanya** (`status = 'active' AND ends_at > now`), sehingga menangkap kasus ini.

## Changes

### `app/jobs/notify_idle_conversation_job.rb`

- Tambah `find_usage(account_id)` — lookup subscription + usage sekali menggunakan `Subscription.active` scope (include cek `ends_at`)
- Tambah `usage_limit_reached?(usage)` — guard: return true jika subscription nil (expired/tidak ada) atau usage exceeded
- Ketika limit reached: mark `IdleConversation` sebagai `completed` + resolve conversation langsung, agar tidak di-loop terus oleh cron
- Increment `usage.increment_ai_responses` setelah API berhasil dipanggil, sebelum `create_message`

## Test plan
- [x] Subscription aktif → idle message terkirim, `ai_responses_count` bertambah
- [x] Subscription expired → idle message tidak terkirim, conversation di-resolve, `IdleConversation` jadi completed
- [x] Subscription status bukan `active` → same behavior di atas
- [x] Usage limit tercapai (`exceeded_limits? = true`) → idle message tidak terkirim
- [x] Error saat lookup usage → job tidak crash, idle message tetap diproses (safe default)