### PR TITLE
fix: skip idle message when inbox channel is inactive

### DIFF
--- a/app/jobs/notify_idle_conversation_job.rb
+++ b/app/jobs/notify_idle_conversation_job.rb
@@ -45,13 +45,12 @@ class NotifyIdleConversationJob < ApplicationJob
 
   def idle_conversation_processor(idle_conversation)
     handle_orphaned_conversation(idle_conversation) && return if orphaned?(idle_conversation)
+    return complete_and_resolve(idle_conversation) unless channel_active?(idle_conversation)
 
     usage = find_usage(idle_conversation.account_id)
     if usage_limit_reached?(usage)
       Rails.logger.warn "[NotifyIdleConversationJob] Subscription inactive for account #{idle_conversation.account_id} — marking idle_conversation #{idle_conversation.id} as completed"
-      idle_conversation.update!(status: :completed)
-      idle_conversation.mark_as_conversation_resolved!
-      return
+      return complete_and_resolve(idle_conversation)
     end
 
     return if (message = generate_message(idle_conversation)).nil?
@@ -60,6 +59,15 @@ class NotifyIdleConversationJob < ApplicationJob
     create_message(message, conversation_attributes(idle_conversation))
     idle_conversation.mark_as_sent!
     idle_conversation.mark_as_conversation_resolved! if idle_conversation.completed?
+  end
+
+  def complete_and_resolve(idle_conversation)
+    idle_conversation.update!(status: :completed)
+    idle_conversation.mark_as_conversation_resolved!
+  end
+
+  def channel_active?(idle_conversation)
+    idle_conversation.conversation.inbox.channel_status
   end
 
   def orphaned?(idle_conversation)


### PR DESCRIPTION
## Summary

- `NotifyIdleConversationJob` tidak memiliki guard terhadap `channel_status` — idle message tetap terkirim meski inbox dinonaktifkan
- Ketika channel di-ON kembali setelah lama OFF, semua `IdleConversation` yang menumpuk akan terkirim

## Perubahan

### `app/jobs/notify_idle_conversation_job.rb`

- Tambah guard `channel_active?` di `idle_conversation_processor` — jika `channel_status = false`, idle_conversation di-mark `:completed` dan conversation di-resolve langsung
- Extract `complete_and_resolve` sebagai private method — menghilangkan duplikasi dengan blok `usage_limit_reached?` yang melakukan hal sama

## Alur guard sekarang

```
1. orphaned?             → delete & return
2. channel_active?       → complete_and_resolve & return  ← NEW
3. usage_limit_reached?  → complete_and_resolve & return
4. generate + kirim pesan
```

## Test plan

- [x] Channel aktif → idle message terkirim normal
- [x] Channel nonaktif → idle message tidak terkirim, `IdleConversation` jadi completed, conversation di-resolve
- [x] Channel dinonaktifkan lalu diaktifkan kembali → tidak ada backlog idle message yang meledak