### PR TITLE
fix: enable notify_upcoming_expiry_user cron job

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -54,10 +54,10 @@ reset_subscription_usage:
   class: "ResetSubscriptionUsageJob"
   queue: scheduled_jobs
 
-# notify_upcoming_expiry_user:
-#   cron: "<%= ENV['NOTIFY_SUBSCRIPTION_EXPIRY_CRON'] || '0 */3 * * *' %>" # Default to every 3 hour
-#   class: 'NotifyUpcomingExpiryUser'
-#   queue: scheduled_jobs
+notify_upcoming_expiry_user:
+  cron: "<%= ENV['NOTIFY_SUBSCRIPTION_EXPIRY_CRON'] || '0 */3 * * *' %>" # Default to every 3 hour
+  class: 'NotifyUpcomingExpiryUser'
+  queue: scheduled_jobs
 
 
 # executed every 5 minutes to send reminders


### PR DESCRIPTION
## Summary
- Enable `notify_upcoming_expiry_user` cron job yang sebelumnya dikomentari di `rc/prod`
- Job ini menjalankan email reminder ketika usage MAU/AI Response hampir habis dan subscription hampir expired

## Changes
- Uncomment `notify_upcoming_expiry_user` di `config/schedule.yml`
- Default schedule: setiap 3 jam (`0 */3 * * *`), dapat di-override via env `NOTIFY_SUBSCRIPTION_EXPIRY_CRON`