### PR TITLE
JKA-0001 | [Tab Umum] Rename Nama Bot

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/aiagents/AiAgentGeneralSettingsView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/AiAgentGeneralSettingsView.vue
@@ -279,6 +279,7 @@ async function submit() {
 
     // flow_data: Build from existing flow_data (already translated), then update with new translations
     const flowData = JSON.parse(JSON.stringify(props.data.flow_data || {}));
+    flowData.bot_name = state.name;
     flowData.agents_config?.forEach(agent_config => {
       if (agent_config.bot_prompt) {
         agent_config.bot_prompt.persona =
@@ -296,6 +297,7 @@ async function submit() {
     const displayFlowData = JSON.parse(
       JSON.stringify(props.data.display_flow_data || {})
     );
+    displayFlowData.bot_name = state.name;
     displayFlowData.agents_config?.forEach(agent_config => {
       if (agent_config.bot_prompt) {
         agent_config.bot_prompt.persona =
@@ -323,6 +325,7 @@ async function submit() {
     displayFlowData.greeting_config = greetingConfig;
 
     const payload = {
+      name: state.name,
       flow_data: flowData,
       display_flow_data: displayFlowData,
     };


### PR DESCRIPTION
## Summary

- Field `name` tidak pernah dimasukkan ke payload saat update, sehingga rename bot tidak tersimpan ke DB
- `bot_name` di dalam `flow_data` dan `display_flow_data` juga tidak diupdate saat rename
- Fix: tambahkan `name: state.name` ke payload, dan update `bot_name` di kedua flow data

## Root Cause

Di `AiAgentGeneralSettingsView.vue`, fungsi `submit()` membangun payload hanya dengan `flow_data` dan `display_flow_data`. Input field nama sudah ada dan terikat ke `state.name` via `v-model`, tapi nilainya tidak pernah dikirim ke backend.

Saat create, `bot_name` di-set dari `params[:name]` via `base_builder.rb`. Saat update, keduanya harus disinkronkan secara manual dari frontend.

## Test plan

- [x] Buka settings AI agent
- [x] Ubah nama bot, klik Save
- [x] Refresh halaman — nama harus tetap berubah
- [x] Cek `flow_data.bot_name` dan `display_flow_data.bot_name` sudah terupdate