### PR TITLE
JKA-0004 | [Bot Config] Tambahkan toggle aktif/nonaktif idle message

### DIFF
--- a/app/controllers/api/v2/accounts/idle_configs_controller.rb
+++ b/app/controllers/api/v2/accounts/idle_configs_controller.rb
@@ -32,6 +32,7 @@ class Api::V2::Accounts::IdleConfigsController < Api::V1::Accounts::BaseControll
   def idle_config_response
     {
       id: @idle_config.id,
+      enabled: @idle_config.enabled,
       duration: @idle_config.duration,
       ai_agent_id: @idle_config.ai_agent_id,
       account_id: @idle_config.account_id,

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/BookingBotView.vue
@@ -88,7 +88,8 @@ const creativityOptions = computed(() => [
 
 // idle time
 const idleConfig = reactive({
-  duration: window.chatwootConfig?.idleConversationDuration || 30,        
+  enabled: true,
+  duration: window.chatwootConfig?.idleConversationDuration || 30,
 });
 
 // Steps: 'auth', 'connected', 'sheetConfig'
@@ -182,6 +183,7 @@ async function loadIdleConfig() {
   try {
     const response = await idleConfigsAPI.getConfig(props.data.id);
     if (response.data) {
+      idleConfig.enabled = response.data.enabled !== undefined ? response.data.enabled : true;
       idleConfig.duration = response.data.duration || 30;
     }
   } catch (error) {
@@ -517,6 +519,7 @@ async function save() {
         message_template: followUpConfig.message
       }),
       idleConfigsAPI.updateConfig(props.data.id, {
+        enabled: idleConfig.enabled,
         duration: idleConfig.duration,
       })
     ]);
@@ -994,20 +997,26 @@ onMounted(async () => {
                   </div>
 
                   <div class="border border-gray-200 dark:border-gray-700 rounded-lg mb-6 bg-white dark:bg-transparent">
-                    <div class="flex items-center p-6">
-                      <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
-                          <circle cx="12" cy="12" r="10"/>
-                          <polyline points="12 6 12 12 16 14"/>
-                        </svg>
+                    <div class="flex items-center justify-between p-6">
+                      <div class="flex items-center">
+                        <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
+                          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
+                            <circle cx="12" cy="12" r="10"/>
+                            <polyline points="12 6 12 12 16 14"/>
+                          </svg>
+                        </div>
+                        <div>
+                          <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
+                          <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
+                        </div>
                       </div>
-                      <div>
-                        <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
-                        <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
-                      </div>
+                      <label class="inline-flex items-center cursor-pointer">
+                        <input type="checkbox" v-model="idleConfig.enabled" class="sr-only peer" :disabled="isSaving">
+                        <div class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+                      </label>
                     </div>
-                    
-                    <div class="border-t border-gray-200 dark:border-gray-700 p-6">
+
+                    <div v-if="idleConfig.enabled" class="border-t border-gray-200 dark:border-gray-700 p-6">
                       <div>
                         <label class="block text-sm font-medium mb-2 text-slate-900 dark:text-slate-25">
                           {{ $t('AGENT_MGMT.EOBOT.IDLE_TIME') }}

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/LeadGenBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/LeadGenBotView.vue
@@ -409,20 +409,26 @@
               </div>
 
               <div class="border border-gray-200 dark:border-gray-700 rounded-lg mb-6 bg-white dark:bg-transparent">
-                <div class="flex items-center p-6">
-                  <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
-                      <circle cx="12" cy="12" r="10"/>
-                      <polyline points="12 6 12 12 16 14"/>
-                    </svg>
+                <div class="flex items-center justify-between p-6">
+                  <div class="flex items-center">
+                    <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
+                        <circle cx="12" cy="12" r="10"/>
+                        <polyline points="12 6 12 12 16 14"/>
+                      </svg>
+                    </div>
+                    <div>
+                      <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
+                      <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
+                    </div>
                   </div>
-                  <div>
-                    <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
-                    <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
-                  </div>
+                  <label class="inline-flex items-center cursor-pointer">
+                    <input type="checkbox" v-model="idleConfig.enabled" class="sr-only peer" :disabled="isSaving">
+                    <div class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+                  </label>
                 </div>
-                
-                <div class="border-t border-gray-200 dark:border-gray-700 p-6">
+
+                <div v-if="idleConfig.enabled" class="border-t border-gray-200 dark:border-gray-700 p-6">
                   <div>
                     <label class="block text-sm font-medium mb-2 text-slate-900 dark:text-slate-25">
                       {{ $t('AGENT_MGMT.EOBOT.IDLE_TIME') }}
@@ -621,7 +627,8 @@ const isDelayEnabled = ref(false);
 
 // idle time
 const idleConfig = reactive({
-  duration: window.chatwootConfig?.idleConversationDuration || 30,       
+  enabled: true,
+  duration: window.chatwootConfig?.idleConversationDuration || 30,
 });
 
 // Helper function to get agent ID by type
@@ -944,6 +951,7 @@ async function saveSettings() {
         message_template: followUpConfig.message
       }),
       idleConfigsAPI.updateConfig(props.data.id, {
+        enabled: idleConfig.enabled,
         duration: idleConfig.duration,
       })
     ]);

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/RestaurantBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/RestaurantBotView.vue
@@ -66,7 +66,8 @@ const creativityOptions = computed(() => [
 
 // idle time
 const idleConfig = reactive({
-  duration: window.chatwootConfig?.idleConversationDuration || 30,        
+  enabled: true,
+  duration: window.chatwootConfig?.idleConversationDuration || 30,
 });
 
 // General Tab - Google Sheets Integration (centralized from parent)
@@ -337,6 +338,7 @@ async function saveGeneralSettings() {
     await Promise.all([
       aiAgents.updateAgent(props.data.id, payload),
       idleConfigsAPI.updateConfig(props.data.id, {
+        enabled: idleConfig.enabled,
         duration: idleConfig.duration
       })
     ]);
@@ -436,6 +438,7 @@ async function loadIdleConfig() {
   try {
     const response = await idleConfigsAPI.getConfig(props.data.id);
     if (response.data) {
+      idleConfig.enabled = response.data.enabled !== undefined ? response.data.enabled : true;
       idleConfig.duration = response.data.duration || 30;
     }
   } catch (error) {
@@ -719,26 +722,33 @@ onMounted(async () => {
                   </div>
                 </div>
                 <div class="border border-gray-200 dark:border-gray-700 rounded-lg mb-6 bg-white dark:bg-transparent">
-                  <div class="flex items-center p-6">
-                    <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
-                        <circle cx="12" cy="12" r="10"/>
-                        <polyline points="12 6 12 12 16 14"/>
-                      </svg>
+                  <div class="flex items-center justify-between p-6">
+                    <div class="flex items-center">
+                      <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
+                          <circle cx="12" cy="12" r="10"/>
+                          <polyline points="12 6 12 12 16 14"/>
+                        </svg>
+                      </div>
+                      <div>
+                        <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
+                        <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
+                      </div>
                     </div>
-                    <div>
-                      <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
-                      <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
-                    </div>
+                    <label class="inline-flex items-center cursor-pointer">
+                      <input type="checkbox" v-model="idleConfig.enabled" class="sr-only peer" :disabled="isSaving">
+                      <div class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+                    </label>
                   </div>
-                  
-                  <div class="border-t border-gray-200 dark:border-gray-700 p-6">
+
+                  <div v-if="idleConfig.enabled" class="border-t border-gray-200 dark:border-gray-700 p-6">
                     <div>
                       <label class="block text-sm font-medium mb-2 text-slate-900 dark:text-slate-25">
                         {{ $t('AGENT_MGMT.EOBOT.IDLE_TIME') }}
                       </label>
                       <select
                         v-model="idleConfig.duration"
+                        :disabled="isSaving"
                         class="text-center w-24 mb-0 p-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed dark:bg-slate-900 dark:border-slate-700 dark:text-white"
                       >
                         <option :value="5">{{ $t('AGENT_MGMT.EOBOT.IDLE_TIME_OPTION_5_MIN') }}</option>

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/SalesBotView.vue
@@ -311,20 +311,26 @@
                 </div>
 
                 <div class="border border-gray-200 dark:border-gray-700 rounded-lg mb-6 bg-white dark:bg-transparent">
-                  <div class="flex items-center p-6">
-                    <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
-                        <circle cx="12" cy="12" r="10"/>
-                        <polyline points="12 6 12 12 16 14"/>
-                      </svg>
+                  <div class="flex items-center justify-between p-6">
+                    <div class="flex items-center">
+                      <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
+                          <circle cx="12" cy="12" r="10"/>
+                          <polyline points="12 6 12 12 16 14"/>
+                        </svg>
+                      </div>
+                      <div>
+                        <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
+                        <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
+                      </div>
                     </div>
-                    <div>
-                      <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
-                      <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
-                    </div>
+                    <label class="inline-flex items-center cursor-pointer">
+                      <input type="checkbox" v-model="idleConfig.enabled" class="sr-only peer" :disabled="isSaving">
+                      <div class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+                    </label>
                   </div>
-                  
-                  <div class="border-t border-gray-200 dark:border-gray-700 p-6">
+
+                  <div v-if="idleConfig.enabled" class="border-t border-gray-200 dark:border-gray-700 p-6">
                     <div>
                       <label class="block text-sm font-medium mb-2 text-slate-900 dark:text-slate-25">
                         {{ $t('AGENT_MGMT.EOBOT.IDLE_TIME') }}
@@ -1781,6 +1787,7 @@ const creativityOptions = computed(() => [
 
 // idle time
 const idleConfig = reactive({
+  enabled: true,
   duration: window.chatwootConfig?.idleConversationDuration || 30,
 });
 
@@ -1822,6 +1829,7 @@ async function loadIdleConfig() {
   try {
     const response = await idleConfigsAPI.getConfig(props.data.id);
     if (response.data) {
+      idleConfig.enabled = response.data.enabled !== undefined ? response.data.enabled : true;
       idleConfig.duration = response.data.duration || 30;
     }
   } catch (error) {
@@ -3415,6 +3423,7 @@ async function saveSettings() {
     await Promise.all([
       aiAgents.updateAgent(props.data.id, payload),
       idleConfigsAPI.updateConfig(props.data.id, {
+        enabled: idleConfig.enabled,
         duration: idleConfig.duration,
       })
     ]);

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/GeneralTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/cs-bot-tabs/GeneralTab.vue
@@ -42,6 +42,7 @@ const creativityOptions = computed(() => [
 
 // idle time
 const idleConfig = reactive({
+  enabled: true,
   duration: window.chatwootConfig?.idleConversationDuration || 30,
 });
 
@@ -161,6 +162,7 @@ async function loadIdleConfig() {
   try {
     const response = await idleConfigsAPI.getConfig(props.data.id);
     if (response.data) {
+      idleConfig.enabled = response.data.enabled !== undefined ? response.data.enabled : true;
       idleConfig.duration = response.data.duration || 30;
     }
   } catch (error) {
@@ -359,6 +361,7 @@ async function save() {
     await Promise.all([
       aiAgents.updateAgent(props.data.id, payload),
       idleConfigsAPI.updateConfig(props.data.id, {
+        enabled: idleConfig.enabled,
         duration: idleConfig.duration
       })
     ]);
@@ -744,20 +747,26 @@ console.log("is ticketAuthError value inside GeneralTab.vue:", !ticketAuthError.
           </div>
         </div>
         <div class="border border-gray-200 dark:border-gray-700 rounded-lg mb-6 bg-white dark:bg-transparent">
-          <div class="flex items-center p-6">
-            <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
-                <circle cx="12" cy="12" r="10"/>
-                <polyline points="12 6 12 12 16 14"/>
-              </svg>
+          <div class="flex items-center justify-between p-6">
+            <div class="flex items-center">
+              <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
+                  <circle cx="12" cy="12" r="10"/>
+                  <polyline points="12 6 12 12 16 14"/>
+                </svg>
+              </div>
+              <div>
+                <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
+                <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
+              </div>
             </div>
-            <div>
-              <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
-              <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
-            </div>
+            <label class="inline-flex items-center cursor-pointer">
+              <input type="checkbox" v-model="idleConfig.enabled" class="sr-only peer" :disabled="isSaving">
+              <div class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+            </label>
           </div>
-          
-          <div class="border-t border-gray-200 dark:border-gray-700 p-6">
+
+          <div v-if="idleConfig.enabled" class="border-t border-gray-200 dark:border-gray-700 p-6">
             <div>
               <label class="block text-sm font-medium mb-2 text-slate-900 dark:text-slate-25">
                 {{ $t('AGENT_MGMT.EOBOT.IDLE_TIME') }}

--- a/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/eo-bot-tabs/GeneralTab.vue
+++ b/app/javascript/dashboard/routes/dashboard/aiagents/botconfigs/eo-bot-tabs/GeneralTab.vue
@@ -7,6 +7,7 @@ import Button from 'dashboard/components-next/button/Button.vue';
 
 import googleSheetsExportAPI from '../../../../../api/googleSheetsExport';
 import aiAgents from '../../../../../api/aiAgents';
+import idleConfigsAPI from '../../../../../api/idleConfigs';
 import { watch } from 'vue';
 
 const props = defineProps({
@@ -36,7 +37,8 @@ const creativityOptions = computed(() => [
 
 // idle time
 const idleConfig = reactive({
-  duration: window.chatwootConfig?.idleConversationDuration || 30,      
+  enabled: true,
+  duration: window.chatwootConfig?.idleConversationDuration || 30,
 });
 
 console.log('=== googleSheetsAuth in GeneralTab.vue', props.googleSheetsAuth);
@@ -93,6 +95,20 @@ watch(
 );
 
 const isSaving = ref(false);
+
+// Load idle config from API
+async function loadIdleConfig() {
+  if (!props.data?.id) return;
+  try {
+    const response = await idleConfigsAPI.getConfig(props.data.id);
+    if (response.data) {
+      idleConfig.enabled = response.data.enabled !== undefined ? response.data.enabled : true;
+      idleConfig.duration = response.data.duration || 30;
+    }
+  } catch (error) {
+    console.error('Failed to load idle config:', error);
+  }
+}
 
 // Local notification state (separate from parent's Google Sheets auth)
 const notification = ref(null);
@@ -294,6 +310,7 @@ async function save() {
     await Promise.all([
       aiAgents.updateAgent(props.data.id, payload),
       idleConfigsAPI.updateConfig(props.data.id, {
+        enabled: idleConfig.enabled,
         duration: idleConfig.duration
       })
     ]);
@@ -536,20 +553,26 @@ console.log("is ticketAuthError value inside GeneralTab.vue:", !ticketAuthError.
                 </div>
               </div>
               <div class="border border-gray-200 dark:border-gray-700 rounded-lg mb-6 bg-white dark:bg-transparent">
-                <div class="flex items-center p-6">
-                  <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
-                      <circle cx="12" cy="12" r="10"/>
-                      <polyline points="12 6 12 12 16 14"/>
-                    </svg>
+                <div class="flex items-center justify-between p-6">
+                  <div class="flex items-center">
+                    <div class="w-10 h-10 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-green-600 dark:text-green-400">
+                        <circle cx="12" cy="12" r="10"/>
+                        <polyline points="12 6 12 12 16 14"/>
+                      </svg>
+                    </div>
+                    <div>
+                      <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
+                      <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
+                    </div>
                   </div>
-                  <div>
-                    <h3 class="font-medium text-slate-900 dark:text-slate-25">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE') }}</h3>
-                    <p class="text-sm text-gray-500 mt-1">{{ $t('AGENT_MGMT.EOBOT.IDLE_STATE_DESC') }}</p>
-                  </div>
+                  <label class="inline-flex items-center cursor-pointer">
+                    <input type="checkbox" v-model="idleConfig.enabled" class="sr-only peer" :disabled="isSaving">
+                    <div class="border solid w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-green-500 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+                  </label>
                 </div>
-                
-                <div class="border-t border-gray-200 dark:border-gray-700 p-6">
+
+                <div v-if="idleConfig.enabled" class="border-t border-gray-200 dark:border-gray-700 p-6">
                   <div>
                     <label class="block text-sm font-medium mb-2 text-slate-900 dark:text-slate-25">
                       {{ $t('AGENT_MGMT.EOBOT.IDLE_TIME') }}

--- a/app/services/captain/copilot/chat_service.rb
+++ b/app/services/captain/copilot/chat_service.rb
@@ -361,6 +361,9 @@ class Captain::Copilot::ChatService
   def end_state_processing(response)
     return unless @context.ai_agent
 
+    idle_config = @context.ai_agent.idle_config
+    return if idle_config && !idle_config.enabled?
+
     attrs = {
       conversation_id: @context.conversation.id,
       inbox_id: @context.inbox_id,


### PR DESCRIPTION
## Summary

- Menambahkan toggle enable/disable idle message pada card **"Follow Up After Idle"** di semua 6 bot view (CS Bot, EO Bot, Lead Gen, Sales, Booking, Restaurant)
- Backend: expose field \`enabled\` pada response \`idle_config\` API (field sudah ada di DB tapi belum direturn)
- Frontend: toggle menggunakan pola yang sama dengan "Tunda Balasan Bot", saat toggle OFF selector durasi disembunyikan (\`v-if\`)
- Backend guard: \`chat_service.rb\` skip pembuatan \`IdleConversation\` record ketika \`enabled = false\`, sehingga idle message tidak terkirim dan tidak ada record yang terbuat

## Commits

- \`JKA-0004 | [Idle Config]\` — Backend: expose \`enabled\` pada idle_config response
- \`JKA-0004 | [Bot Config]\` — Frontend: toggle di CS Bot, EO Bot, Lead Gen, Sales, Booking, Restaurant Bot
- \`JKA-0004 | [Idle Config]\` — Backend: skip idle conversation creation ketika idle dinonaktifkan

## Test plan

- [x] Buka pengaturan salah satu bot → pastikan toggle muncul di bagian "Follow Up After Idle"
- [x] Toggle OFF → selector durasi hilang
- [x] Toggle ON → selector durasi muncul kembali
- [x] Simpan dengan toggle OFF → reload halaman → toggle tetap OFF
- [x] Simpan dengan toggle ON → reload halaman → toggle tetap ON
- [x] Toggle OFF, kirim pesan ke bot → tunggu idle duration → pastikan **tidak ada** idle message terkirim
- [x] Toggle ON, kirim pesan ke bot → tunggu idle duration → pastikan idle message terkirim
- [x] Uji di semua 6 bot: CS Bot, EO Bot, Lead Gen, Sales, Booking, Restaurant