### PR TITLE
JKA-0004 | [Idle Config] Resolve conversation otomatis ketika idle dinonaktifkan

### DIFF
--- a/app/jobs/notify_idle_conversation_job.rb
+++ b/app/jobs/notify_idle_conversation_job.rb
@@ -18,13 +18,21 @@ class NotifyIdleConversationJob < ApplicationJob
     preload_durations(conversations)
 
     conversations.each do |idle_conversation|
-      duration = DEFAULT_END_STATE_DURATION # default duration
-      duration = @duration_cache[idle_conversation.ai_agent_id] || DEFAULT_DURATION if idle_conversation.step.zero?
-      unit = idle_conversation.step.zero? ? DEFAULT_UNIT : DEFAULT_END_STATE_UNIT
+      enabled = @enabled_cache.fetch(idle_conversation.ai_agent_id, true)
+
+      if enabled
+        duration = DEFAULT_END_STATE_DURATION
+        duration = @duration_cache[idle_conversation.ai_agent_id] || DEFAULT_DURATION if idle_conversation.step.zero?
+        unit = idle_conversation.step.zero? ? DEFAULT_UNIT : DEFAULT_END_STATE_UNIT
+      else
+        base_duration = @duration_cache[idle_conversation.ai_agent_id] || DEFAULT_DURATION
+        duration = [base_duration, 30].max
+        unit = 'minutes'
+      end
 
       next unless idle_since?(idle_conversation.conversation.last_activity_at, duration, unit)
 
-      idle_conversation_processor(idle_conversation)
+      enabled ? idle_conversation_processor(idle_conversation) : complete_and_resolve(idle_conversation)
     end
 
     Rails.logger.info('[NotifyIdleConversationJob] Completed processing idle conversations')
@@ -34,9 +42,9 @@ class NotifyIdleConversationJob < ApplicationJob
 
   def preload_durations(conversations)
     ai_agent_ids = conversations.map(&:ai_agent_id).uniq
-    @duration_cache = IdleConfig.where(ai_agent_id: ai_agent_ids)
-                                .pluck(:ai_agent_id, :duration)
-                                .to_h
+    configs = IdleConfig.where(ai_agent_id: ai_agent_ids).pluck(:ai_agent_id, :duration, :enabled)
+    @duration_cache = configs.to_h { |id, dur, _| [id, dur] }
+    @enabled_cache = configs.to_h { |id, _, en| [id, en] }
   end
 
   def idle_since?(last_activity_at, duration, unit)

--- a/app/services/captain/copilot/chat_service.rb
+++ b/app/services/captain/copilot/chat_service.rb
@@ -312,9 +312,6 @@ class Captain::Copilot::ChatService
   def end_state_processing(response)
     return unless @context.ai_agent
 
-    idle_config = @context.ai_agent.idle_config
-    return if idle_config && !idle_config.enabled?
-
     attrs = {
       conversation_id: @context.conversation.id,
       inbox_id: @context.inbox_id,


### PR DESCRIPTION
## Summary

- Ketika idle message dinonaktifkan (`enabled = false`), conversation tetap di-resolve otomatis setelah batas waktu tanpa mengirim pesan idle
- Durasi resolve menggunakan nilai dari `idle_config.duration` dengan minimum **30 menit**
- Jika tidak ada `idle_config` record → pakai default (flow normal)
- Enabled check di `chat_service.rb` dihapus dan dipindah ke `notify_idle_conversation_job.rb`

## Behavior

| Kondisi | Durasi | Aksi |
|---|---|---|
| `enabled = true` | dari config / DEFAULT | kirim idle message → resolve |
| `enabled = false` | `max(config.duration, 30)` menit | langsung resolve, tanpa pesan |
| Tidak ada idle_config | DEFAULT (env) | flow normal |

## Commits

- `JKA-0004 | [Idle Config]` — Hapus enabled check dari chat_service, pindah ke job
- `JKA-0004 | [Idle Config]` — Resolve conversation otomatis ketika idle dinonaktifkan

## Test plan

- [x] Toggle idle OFF pada bot → kirim pesan ke bot → tunggu `max(duration, 30)` menit → conversation ter-resolve otomatis tanpa pesan idle
- [x] Toggle idle ON → flow normal (pesan idle terkirim, lalu resolve)
- [x] Hapus idle_config record dari DB → pastikan flow normal tetap berjalan (pakai default)
- [x] Set `idle_config.duration = 10` menit + disabled → pastikan resolve setelah 30 menit (bukan 10)
- [x] Set `idle_config.duration = 60` menit + disabled → pastikan resolve setelah 60 menit